### PR TITLE
Fix root logger config

### DIFF
--- a/sanic/log.py
+++ b/sanic/log.py
@@ -6,11 +6,11 @@ LOGGING_CONFIG_DEFAULTS = dict(
     version=1,
     disable_existing_loggers=False,
 
+    root={
+        "level": "INFO",
+        "handlers": ["console"]
+    },
     loggers={
-        "root": {
-            "level": "INFO",
-            "handlers": ["console"]
-        },
         "sanic.error": {
             "level": "INFO",
             "handlers": ["error_console"],


### PR DESCRIPTION
According to the [doc](https://docs.python.org/3/library/logging.config.html#dictionary-schema-details), root logger configuration should be given as a separate key, not within `loggers` array.
Previous configuration would create a new (regular) logger named `root` instead of configuring root logger which in turn remained with its default `WARNING` loglevel.