### PR TITLE
Request.py: Updated base class from dict to object in Request wrapper…

### DIFF
--- a/sanic/request.py
+++ b/sanic/request.py
@@ -42,7 +42,7 @@ class RequestParameters(dict):
         return super().get(name, default)
 
 
-class Request(dict):
+class Request(object):
     """Properties of an HTTP request such as URL, headers, etc."""
     __slots__ = (
         'app', 'headers', 'version', 'method', '_cookies', 'transport',

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -78,6 +78,9 @@ class Request(object):
                                        self.method,
                                        self.path)
 
+    def __nonzero__(self):
+        return True if self.app else False
+
     @property
     def json(self):
         if self.parsed_json is None:


### PR DESCRIPTION
Fixed issue #1151 which occurred because Request wrapper used in Sanic was inheriting from dict base class and in Request constructor,  base class dict constructor was not getting called and also Request was not overriding __len__ method of base class dict which was giving 0 as output everytime it is being called in "if request" in exception handler method. Thus updated base class from dict to object as no particular functionality of dict class is being used in Request class.