### PR TITLE
fix #1253

### DIFF
--- a/sanic/request.py
+++ b/sanic/request.py
@@ -127,7 +127,7 @@ class Request(dict):
             try:
                 if content_type == 'application/x-www-form-urlencoded':
                     self.parsed_form = RequestParameters(
-                        parse_qs(self.body.decode('utf-8'), encoding='latin1'))
+                        parse_qs(self.body.decode('latin1'), encoding='latin1'))
                 elif content_type == 'multipart/form-data':
                     # TODO: Stream this instead of reading to/from memory
                     boundary = parameters['boundary'].encode('utf-8')

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -127,7 +127,7 @@ class Request(dict):
             try:
                 if content_type == 'application/x-www-form-urlencoded':
                     self.parsed_form = RequestParameters(
-                        parse_qs(self.body.decode('utf-8')))
+                        parse_qs(self.body.decode('utf-8'), encoding='latin1'))
                 elif content_type == 'multipart/form-data':
                     # TODO: Stream this instead of reading to/from memory
                     boundary = parameters['boundary'].encode('utf-8')


### PR DESCRIPTION
This fix refer to tornado (another python web framework), which solve the same problem in function parse_qs_bytes() in file tornado/escape.py:

    def parse_qs_bytes(qs, keep_blank_values=False, strict_parsing=False):
        """Parses a query string like urlparse.parse_qs, but returns the
        values as byte strings.

        Keys still become type str (interpreted as latin1 in python3!)
        because it's too painful to keep them as byte strings in
        python3 and in practice they're nearly always ascii anyway.
        """
        **# This is gross, but python3 doesn't give us another way.
        # Latin1 is the universal donor of character encodings.
        result = _parse_qs(qs, keep_blank_values, strict_parsing,
                           encoding='latin1', errors='strict')**
        encoded = {}
        for k, v in result.items():
            encoded[k] = [i.encode('latin1') for i in v]
        return encoded
