### PR TITLE
Change content type to file type on File.type

### DIFF
--- a/sanic/request.py
+++ b/sanic/request.py
@@ -291,7 +291,6 @@ def parse_multipart_form(body, boundary):
     form_parts = body.split(boundary)
     for form_part in form_parts[1:-1]:
         file_name = None
-        content_type = 'text/plain'
         content_charset = 'utf-8'
         field_name = None
         line_index = 2
@@ -313,7 +312,6 @@ def parse_multipart_form(body, boundary):
                 file_name = form_parameters.get('filename')
                 field_name = form_parameters.get('name')
             elif form_header_field == 'content-type':
-                content_type = form_header_value
                 content_charset = form_parameters.get('charset', 'utf-8')
 
         if field_name:

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -5,6 +5,7 @@ from cgi import parse_header
 from collections import namedtuple
 from http.cookies import SimpleCookie
 from httptools import parse_url
+from mimetypes import guess_type
 from urllib.parse import parse_qs, urlunparse
 
 try:
@@ -318,7 +319,8 @@ def parse_multipart_form(body, boundary):
         if field_name:
             post_data = form_part[line_index:-4]
             if file_name:
-                form_file = File(type=content_type,
+                file_type = guess_type(file_name)[0] or 'text/plain'
+                form_file = File(type=file_type,
                                  name=file_name,
                                  body=post_data)
                 if field_name in files:


### PR DESCRIPTION
As I detailed on #1311, the current behavior seems incorrect or at the very least, confusing. Please read that first.

This change moves File.type from content type (determined from request's mimetype, which seems to always be `application/octet-stream`) to file's actual type (determined with `mimetypes` library based on file's extension, same as how type determination is done on rest of the code).

---

~~With this change the `content_type` variable on `parse_multipart_form` ends up being unused, I can remove or comment that if needed.~~

I also removed `content_type` variable on `parse_multipart_form` as travis detected it as an unused variable and caused CI to fail.

---

Closes #1311