### PR TITLE
Add multidict to readthedocs environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,4 +17,5 @@ dependencies:
   - aiofiles>=0.3.0
   - websockets>=3.2
   - sphinxcontrib-asyncio>=0.2.0
+  - multidict>=4.0<5.0
   - https://github.com/channelcat/docutils-fork/zipball/master


### PR DESCRIPTION
readthedocs builds were failing since multidict wasn't available

Signed-off-by: Eli Uriegas <seemethere101@gmail.com>