### PR TITLE
Try not to stringify exception in logging messages

### DIFF
--- a/sanic/__main__.py
+++ b/sanic/__main__.py
@@ -41,4 +41,4 @@ if __name__ == "__main__":
                      "  Example Module: project.sanic_server.app"
                      .format(e.name))
     except ValueError as e:
-        logger.error("{}".format(e))
+        logger.exception("Failed to run app")

--- a/sanic/handlers.py
+++ b/sanic/handlers.py
@@ -79,7 +79,7 @@ class ErrorHandler:
         response = None
         try:
             if handler:
-                response = handler(req, exception)
+                response = handler(request, exception)
             if response is None:
                 response = self.default(request, exception)
         except Exception:

--- a/sanic/handlers.py
+++ b/sanic/handlers.py
@@ -1,5 +1,5 @@
 import sys
-from traceback import extract_tb
+from traceback import extract_tb, format_exc
 
 from sanic.exceptions import (
     ContentRangeError,

--- a/sanic/handlers.py
+++ b/sanic/handlers.py
@@ -79,10 +79,11 @@ class ErrorHandler:
         response = None
         try:
             if handler:
-                response = handler(request, exception)
+                response = handler(req, exception)
             if response is None:
                 response = self.default(request, exception)
         except Exception:
+            self.log(format_exc())
             try:
                 url = repr(request.url)
             except AttributeError:
@@ -99,12 +100,11 @@ class ErrorHandler:
 
     def log(self, message, level='error'):
         """
-        Override this method in an ErrorHandler subclass to prevent
-        logging exceptions.
+        Deprecated, do not use.
         """
-        getattr(logger, level)(message)
 
     def default(self, request, exception):
+        self.log(format_exc())
         try:
             url = repr(request.url)
         except AttributeError:

--- a/sanic/log.py
+++ b/sanic/log.py
@@ -58,6 +58,6 @@ LOGGING_CONFIG_DEFAULTS = dict(
 )
 
 
-logger = logging.getLogger('root')
+logger = logging.getLogger('sanic.root')
 error_logger = logging.getLogger('sanic.error')
 access_logger = logging.getLogger('sanic.access')

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -441,7 +441,7 @@ class HttpProtocol(asyncio.Protocol):
             logger.error("Transport closed @ %s and exception "
                          "experienced during error handling",
                          self.transport.get_extra_info('peername'))
-            logger.debug('Exception:\n%s', traceback.format_exc())
+            logger.debug('Exception:', exc_info=True)
         else:
             exception = ServerError(message)
             self.write_error(exception)

--- a/sanic/testing.py
+++ b/sanic/testing.py
@@ -1,4 +1,3 @@
-import traceback
 from json import JSONDecodeError
 from sanic.log import logger
 from sanic.exceptions import MethodNotSupported
@@ -73,8 +72,7 @@ class SanicTestClient:
                     **request_kwargs)
                 results[-1] = response
             except Exception as e:
-                logger.error(
-                    'Exception:\n{}'.format(traceback.format_exc()))
+                logger.exception('Exception')
                 exceptions.append(e)
             self.app.stop()
 


### PR DESCRIPTION
This just fixes the worst offenders that trip up error reporting tools
like Sentry.io

fix #1332 