### PR TITLE
Simplify request ip and port retrieval logic

### DIFF
--- a/sanic/request.py
+++ b/sanic/request.py
@@ -1,6 +1,5 @@
 import sys
 import json
-import socket
 from cgi import parse_header
 from collections import namedtuple
 from http.cookies import SimpleCookie
@@ -192,18 +191,10 @@ class Request(dict):
         return self._socket
 
     def _get_address(self):
-        sock = self.transport.get_extra_info('socket')
-
-        if sock.family == socket.AF_INET:
-            self._socket = (self.transport.get_extra_info('peername') or
-                            (None, None))
-            self._ip, self._port = self._socket
-        elif sock.family == socket.AF_INET6:
-            self._socket = (self.transport.get_extra_info('peername') or
-                            (None, None, None, None))
-            self._ip, self._port, *_ = self._socket
-        else:
-            self._ip, self._port = (None, None)
+        self._socket = self.transport.get_extra_info('peername') or \
+                        (None, None)
+        self._ip = self._socket[0]
+        self._port = self._socket[1]
 
     @property
     def remote_addr(self):


### PR DESCRIPTION
This change also ensures that cases where transport stream is already closed is handled gracefully.

The previous change to handle IPv6 (#1053) did not account for the case where the the stream was already closed and `self.transport.get_extra_info('socket')` returns `None`. This works around the issue by avoiding the need for socket retrieval.

Note that the exception was only triggered in a scenario where [`debug` was enabled and the request ip was accessed when uvloop threw a `RuntimeError`](https://github.com/huge-success/sanic/blob/master/sanic/server.py#L335-L337).