### PR TITLE
WIP: Add ability to modify matched router parameters in middleware

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,8 @@ Guides
    sanic/ssl
    sanic/logging
    sanic/testing
+   sanic/debug_mode
+   sanic/versioning
    sanic/deploying
    sanic/extensions
    sanic/contributing

--- a/docs/sanic/middleware.md
+++ b/docs/sanic/middleware.md
@@ -79,7 +79,7 @@ and the response will be returned. If this occurs to a request before the
 relevant user route handler is reached, the handler will never be called.
 Returning a response will also prevent any further middleware from running.
 
-```python
+```
 @app.middleware('request')
 async def halt_request(request):
 	return text('I halted the request')
@@ -102,7 +102,7 @@ These listeners are implemented as decorators on functions which accept the app 
 
 For example:
 
-```python
+```
 @app.listener('before_server_start')
 async def setup_db(app, loop):
     app.db = await db_setup()
@@ -124,7 +124,7 @@ It's also possible to register a listener using the `register_listener` method.
 This may be useful if you define your listeners in another module besides
 the one you instantiate your app in.
 
-```python
+```
 app = Sanic()
 
 async def setup_db(app, loop):
@@ -137,7 +137,7 @@ app.register_listener(setup_db, 'before_server_start')
 If you want to schedule a background task to run after the loop has started,
 Sanic provides the `add_task` method to easily do so.
 
-```python
+```
 async def notify_server_started_after_five_seconds():
     await asyncio.sleep(5)
     print('Server successfully started!')
@@ -147,7 +147,7 @@ app.add_task(notify_server_started_after_five_seconds())
 
 Sanic will attempt to automatically inject the app, passing it as an argument to the task:
 
-```python
+```
 async def notify_server_started_after_five_seconds(app):
     await asyncio.sleep(5)
     print(app.name)
@@ -157,7 +157,7 @@ app.add_task(notify_server_started_after_five_seconds)
 
 Or you can pass the app explicitly for the same effect:
 
-```python
+```
 async def notify_server_started_after_five_seconds(app):
     await asyncio.sleep(5)
     print(app.name)

--- a/docs/sanic/middleware.md
+++ b/docs/sanic/middleware.md
@@ -53,6 +53,25 @@ The above code will apply the two middleware in order. First, the middleware
 header for preventing Cross-Site-Scripting (XSS) attacks. These two functions
 are invoked *after* a user function returns a response.
 
+## Modifying the request parameters
+
+Middleware can also be used to make modifications to the matched request parameters. The matched request parameters can be accessed as `request.match_info`, and can also be modified before you access it in your view.
+
+```
+@app.middleware('request')
+async def replace_kwargs(request):
+    request.match_info = {
+        k: v.replace('-', '_')
+        for k, v in request.match_info.items()
+    }
+
+@app.route('/tag/<tag>')
+async def tag_handler(request, tag):
+    return text('Tag - {}'.format(tag))
+```
+
+In the above example, if you were to access `/tag/foo-bar`, it would translate the `tag` parameter to `foo_bar` as the matched value.
+
 ## Responding early
 
 If middleware returns a `HTTPResponse` object, the request will stop processing
@@ -79,7 +98,7 @@ If you want to execute startup/teardown code as your server starts or closes, yo
 - `before_server_stop`
 - `after_server_stop`
 
-These listeners are implemented as decorators on functions which accept the app object as well as the asyncio loop. 
+These listeners are implemented as decorators on functions which accept the app object as well as the asyncio loop.
 
 For example:
 
@@ -101,16 +120,16 @@ async def close_db(app, loop):
     await app.db.close()
 ```
 
-It's also possible to register a listener using the `register_listener` method. 
+It's also possible to register a listener using the `register_listener` method.
 This may be useful if you define your listeners in another module besides
 the one you instantiate your app in.
 
 ```python
 app = Sanic()
-    
+
 async def setup_db(app, loop):
     app.db = await db_setup()
-    
+
 app.register_listener(setup_db, 'before_server_start')
 
 ```

--- a/docs/sanic/websocket.rst
+++ b/docs/sanic/websocket.rst
@@ -43,6 +43,7 @@ and ``recv`` methods to send and receive data respectively.
 You could setup your own WebSocket configuration through ``app.config``, like
 
 .. code:: python
+
     app.config.WEBSOCKET_MAX_SIZE = 2 ** 20
     app.config.WEBSOCKET_MAX_QUEUE = 32
     app.config.WEBSOCKET_READ_LIMIT = 2 ** 16

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@ aiofiles
 aiohttp>=2.3.0,<=3.2.1
 chardet<=2.3.0
 beautifulsoup4
+black==18.9b0
 coverage
 httptools>=0.0.10
 flake8

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -370,8 +370,7 @@ class Sanic:
     ):
         """Decorate a function to be registered as a websocket route
         :param uri: path of the URL
-        :param subprotocols: optional list of strings with the supported
-                             subprotocols
+        :param subprotocols: optional list of strings with the supported subprotocols
         :param host:
         :return: decorated function
         """

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -67,6 +67,7 @@ class Request(dict):
         "_port",
         "__weakref__",
         "raw_url",
+        "_match_info",
     )
 
     def __init__(self, url_bytes, headers, version, method, transport):
@@ -89,6 +90,7 @@ class Request(dict):
         self.uri_template = None
         self._cookies = None
         self.stream = None
+        self._match_info = None
 
     def __repr__(self):
         if self.method is None or not self.path:
@@ -269,7 +271,13 @@ class Request(dict):
     @property
     def match_info(self):
         """return matched info after resolving route"""
+        if self._match_info is not None:
+            return self._match_info
         return self.app.router.get(self)[2]
+
+    @match_info.setter
+    def match_info(self, value):
+        self._match_info = value
 
     @property
     def path(self):

--- a/sanic/router.py
+++ b/sanic/router.py
@@ -391,15 +391,19 @@ class Router:
         """
         # No virtual hosts specified; default behavior
         if not self.hosts:
-            return self._get(request.path, request.method, "")
+            handler, args, kwargs, uri = self._get(request.path, request.method, "")
         # virtual hosts specified; try to match route to the host header
         try:
-            return self._get(
+            handler, args, kwargs, uri = self._get(
                 request.path, request.method, request.headers.get("Host", "")
             )
         # try default hosts
         except NotFound:
-            return self._get(request.path, request.method, "")
+            handler, args, kwargs, uri = self._get(request.path, request.method, "")
+
+        kwargs = kwargs if request._match_info is None else request._match_info
+
+        return handler, args, kwargs, uri
 
     def get_supported_methods(self, url):
         """Get a list of supported methods for a url and optional host.

--- a/sanic/router.py
+++ b/sanic/router.py
@@ -391,16 +391,17 @@ class Router:
         """
         # No virtual hosts specified; default behavior
         if not self.hosts:
-            handler, args, kwargs, uri = self._get(request.path, request.method, "")
+            processed = self._get(request.path, request.method, "")
         # virtual hosts specified; try to match route to the host header
         try:
-            handler, args, kwargs, uri = self._get(
+            processed = self._get(
                 request.path, request.method, request.headers.get("Host", "")
             )
         # try default hosts
         except NotFound:
-            handler, args, kwargs, uri = self._get(request.path, request.method, "")
+            processed = self._get(request.path, request.method, "")
 
+        handler, args, kwargs, uri = processed
         kwargs = kwargs if request._match_info is None else request._match_info
 
         return handler, args, kwargs, uri


### PR DESCRIPTION
Currently, there is no way to modify the matched parameter values on the router in the middleware.

Part of the problem is that the router is called potentially multiple times in the same request. This PR **does not** attempt to fix that problem. But, instead it tries to allow both the getting and setting of matched parameter values using the existing `request.match_info`.