### PR TITLE
Allow sanic test client to bind to a random port

### DIFF
--- a/docs/sanic/testing.md
+++ b/docs/sanic/testing.md
@@ -59,6 +59,23 @@ the available arguments to aiohttp can be found
 [in the documentation for ClientSession](https://aiohttp.readthedocs.io/en/stable/client_reference.html#client-session).
 
 
+## Using a random port
+
+If you need to test using a free unpriveleged port chosen by the kernel
+instead of the default with `SanicTestClient`, you can do so by specifying
+`port=None`. On most systems the port will be in the range 1024 to 65535.
+
+```python
+# Import the Sanic app, usually created with Sanic(__name__)
+from external_server import app
+from sanic.testing import SanicTestClient
+
+def test_index_returns_200():
+    request, response = SanicTestClient(app, port=None).get('/')
+    assert response.status == 200
+```
+
+
 ## pytest-sanic
 
 [pytest-sanic](https://github.com/yunstanford/pytest-sanic) is a pytest plugin, it helps you to test your code asynchronously.

--- a/tests/test_test_client_port.py
+++ b/tests/test_test_client_port.py
@@ -1,0 +1,34 @@
+import socket
+
+from sanic.testing import PORT, SanicTestClient
+from sanic.response import json, text
+
+# ------------------------------------------------------------ #
+#  UTF-8
+# ------------------------------------------------------------ #
+
+
+def test_test_client_port_none(app):
+    @app.get('/get')
+    def handler(request):
+        return text('OK')
+
+    test_client = SanicTestClient(app, port=None)
+
+    request, response = test_client.get('/get')
+    assert response.text == 'OK'
+
+    request, response = test_client.post('/get')
+    assert response.status == 405
+
+
+def test_test_client_port_default(app):
+    @app.get('/get')
+    def handler(request):
+        return json(request.transport.get_extra_info('sockname')[1])
+
+    test_client = SanicTestClient(app)
+    assert test_client.port == PORT
+
+    request, response = test_client.get('/get')
+    assert response.json == PORT


### PR DESCRIPTION
I like to run tests with detox, but using `sanic.Sanic.test_client` causes issues because of multiple servers trying to simultaneously bind to `sanic.testing.PORT`.

This solves that problem by having `SanicTestClient` use `socket` to bind to a random port when `port=None`.