### PR TITLE
Created methods to append and finish body content on Request

### DIFF
--- a/sanic/request.py
+++ b/sanic/request.py
@@ -85,7 +85,7 @@ class Request(dict):
         self.transport = transport
 
         # Init but do not inhale
-        self.body = []
+        self.body_init()
         self.parsed_json = None
         self.parsed_form = None
         self.parsed_files = None
@@ -106,11 +106,14 @@ class Request(dict):
             return True
         return False
 
-    def body_append(self, data):
+    def body_init(self):
+        self.body = []
+
+    def body_push(self, data):
         self.body.append(data)
 
     def body_finish(self):
-        self.body = b''.join(self.body)
+        self.body = b"".join(self.body)
 
     @property
     def json(self):

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -106,6 +106,12 @@ class Request(dict):
             return True
         return False
 
+    def body_append(self, data):
+        self.body.append(data)
+
+    def body_finish(self):
+        self.body = b''.join(self.body)
+
     @property
     def json(self):
         if self.parsed_json is None:

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -300,7 +300,7 @@ class HttpProtocol(asyncio.Protocol):
                 self.request.stream.put(body)
             )
             return
-        self.request.body_append(body)
+        self.request.body_push(body)
 
     def on_message_complete(self):
         # Entire request (headers and whole body) is received.
@@ -798,4 +798,3 @@ def serve_multiple(server_settings, workers):
     for process in processes:
         process.terminate()
     server_settings.get("sock").close()
-

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -300,7 +300,7 @@ class HttpProtocol(asyncio.Protocol):
                 self.request.stream.put(body)
             )
             return
-        self.request.body.append(body)
+        self.request.body_append(body)
 
     def on_message_complete(self):
         # Entire request (headers and whole body) is received.
@@ -313,7 +313,7 @@ class HttpProtocol(asyncio.Protocol):
                 self.request.stream.put(None)
             )
             return
-        self.request.body = b"".join(self.request.body)
+        self.request.body_finish()
         self.execute_request_handler()
 
     def execute_request_handler(self):
@@ -798,3 +798,4 @@ def serve_multiple(server_settings, workers):
     for process in processes:
         process.terminate()
     server_settings.get("sock").close()
+

--- a/tests/test_custom_request.py
+++ b/tests/test_custom_request.py
@@ -1,0 +1,53 @@
+from io import BytesIO
+
+from sanic import Sanic
+from sanic.request import Request
+from sanic.response import json_dumps, text
+
+
+class CustomRequest(Request):
+    __slots__ = ("body_buffer",)
+
+    def body_init(self):
+        self.body_buffer = BytesIO()
+
+    def body_push(self, data):
+        self.body_buffer.write(data)
+
+    def body_finish(self):
+        self.body = self.body_buffer.getvalue()
+        self.body_buffer.close()
+
+
+def test_custom_request():
+    app = Sanic(request_class=CustomRequest)
+
+    @app.route("/post", methods=["POST"])
+    async def post_handler(request):
+        return text("OK")
+
+    @app.route("/get")
+    async def get_handler(request):
+        return text("OK")
+
+    payload = {"test": "OK"}
+    headers = {"content-type": "application/json"}
+
+    request, response = app.test_client.post(
+        "/post", data=json_dumps(payload), headers=headers
+    )
+
+    assert isinstance(request.body_buffer, BytesIO)
+    assert request.body_buffer.closed
+    assert request.body == b'{"test":"OK"}'
+    assert request.json.get("test") == "OK"
+    assert response.text == "OK"
+    assert response.status == 200
+
+    request, response = app.test_client.get("/get")
+
+    assert isinstance(request.body_buffer, BytesIO)
+    assert request.body_buffer.closed
+    assert request.body == b""
+    assert response.text == "OK"
+    assert response.status == 200


### PR DESCRIPTION
Replaces #1310 

## original description

Hi! I just created two methods to append and finish the body content "feed" on request.py so the underlying body instance can have certain flexibility (example: one could use `BytesIO` instead of a `list` for storing the body data if a custom Request-like class is provided to the `Sanic` constructor).

I also modified server.py to reflect the changes on the `Request` class.

If any documentation is required regarding this, please let me know. Also, I'm not sure if this change is the best approach to the `Request.body` attribute so I'm open to suggestions :wink: