### PR TITLE
Resolve build of latex documentation relating to markdown lists

### DIFF
--- a/docs/sanic/contributing.md
+++ b/docs/sanic/contributing.md
@@ -29,8 +29,8 @@ See it's that simple!
 ## Pull requests!
 
 So the pull request approval rules are pretty simple:
-1. All pull requests must pass unit tests
-* All pull requests must be reviewed and approved by at least 
+* All pull requests must pass unit tests
+* All pull requests must be reviewed and approved by at least
 one current collaborator on the project
 * All pull requests must pass flake8 checks
 * If you decide to remove/change anything from any common interface

--- a/docs/sanic/getting_started.md
+++ b/docs/sanic/getting_started.md
@@ -4,8 +4,13 @@ Make sure you have both [pip](https://pip.pypa.io/en/stable/installing/) and at
 least version 3.5 of Python before starting. Sanic uses the new `async`/`await`
 syntax, so earlier versions of python won't work.
 
-1. Install Sanic: `python3 -m pip install sanic`
-2. Create a file called `main.py` with the following code:
+## 1. Install Sanic
+
+  ```
+  python3 -m pip install sanic
+  ```
+
+##  2. Create a file called `main.py`
 
   ```python
   from sanic import Sanic
@@ -20,9 +25,16 @@ syntax, so earlier versions of python won't work.
   if __name__ == "__main__":
       app.run(host="0.0.0.0", port=8000)
   ```
-  
-3. Run the server: `python3 main.py`
-4. Open the address `http://0.0.0.0:8000` in your web browser. You should see
-   the message *Hello world!*.
+
+## 3. Run the server
+
+  ```
+  python3 main.py
+  ```
+
+## 4. Check your browser
+
+Open the address `http://0.0.0.0:8000` in your web browser. You should see
+the message *Hello world!*.
 
 You now have a working Sanic server!


### PR DESCRIPTION
I jumped the gun on #1383. It only resolved the HTML docs (which are now updated on RTD). There was still a failure for latex relating to enumerated lists in MD.

Again, I opted for the easier route on this one just to get it built since we will be redoing the docs in the near future to move everything to RST.