### PR TITLE
router parameter pattern supports negative integer

### DIFF
--- a/sanic/router.py
+++ b/sanic/router.py
@@ -13,7 +13,7 @@ Parameter = namedtuple('Parameter', ['name', 'cast'])
 
 REGEX_TYPES = {
     'string': (str, r'[^/]+'),
-    'int': (int, r'\d+'),
+    'int': (int, r'-?\d+'),
     'number': (float, r'[0-9\\.]+'),
     'alpha': (str, r'[A-Za-z]+'),
     'path': (str, r'[^/].*?'),


### PR DESCRIPTION
such as:
/my/url/<int_param:int>

now int_param can be a negative integer.