### PR TITLE
Add "extra" parameter in FutureRoute

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -152,6 +152,7 @@ class Sanic:
         stream=False,
         version=None,
         name=None,
+        extra=None,
     ):
         """Decorate a function to be registered as a route
 
@@ -161,6 +162,7 @@ class Sanic:
         :param strict_slashes:
         :param stream:
         :param version:
+        :param extra:
         :param name: user defined route name for url_for
         :return: decorated function
         """
@@ -190,6 +192,7 @@ class Sanic:
                     strict_slashes=strict_slashes,
                     version=version,
                     name=name,
+                    extra=extra,
                 )
                 return handler
             else:
@@ -202,7 +205,13 @@ class Sanic:
 
     # Shorthand method decorators
     def get(
-        self, uri, host=None, strict_slashes=None, version=None, name=None
+        self,
+        uri,
+        host=None,
+        strict_slashes=None,
+        version=None,
+        name=None,
+        extra=None,
     ):
         return self.route(
             uri,
@@ -221,6 +230,7 @@ class Sanic:
         stream=False,
         version=None,
         name=None,
+        extra=None,
     ):
         return self.route(
             uri,
@@ -230,6 +240,7 @@ class Sanic:
             stream=stream,
             version=version,
             name=name,
+            extra=extra,
         )
 
     def put(
@@ -240,6 +251,7 @@ class Sanic:
         stream=False,
         version=None,
         name=None,
+        extra=None,
     ):
         return self.route(
             uri,
@@ -249,10 +261,17 @@ class Sanic:
             stream=stream,
             version=version,
             name=name,
+            extra=extra,
         )
 
     def head(
-        self, uri, host=None, strict_slashes=None, version=None, name=None
+        self,
+        uri,
+        host=None,
+        strict_slashes=None,
+        version=None,
+        name=None,
+        extra=None,
     ):
         return self.route(
             uri,
@@ -261,10 +280,17 @@ class Sanic:
             strict_slashes=strict_slashes,
             version=version,
             name=name,
+            extra=extra,
         )
 
     def options(
-        self, uri, host=None, strict_slashes=None, version=None, name=None
+        self,
+        uri,
+        host=None,
+        strict_slashes=None,
+        version=None,
+        name=None,
+        extra=None,
     ):
         return self.route(
             uri,
@@ -273,6 +299,7 @@ class Sanic:
             strict_slashes=strict_slashes,
             version=version,
             name=name,
+            extra=None,
         )
 
     def patch(
@@ -283,6 +310,7 @@ class Sanic:
         stream=False,
         version=None,
         name=None,
+        extra=None,
     ):
         return self.route(
             uri,
@@ -292,10 +320,17 @@ class Sanic:
             stream=stream,
             version=version,
             name=name,
+            extra=extra,
         )
 
     def delete(
-        self, uri, host=None, strict_slashes=None, version=None, name=None
+        self,
+        uri,
+        host=None,
+        strict_slashes=None,
+        version=None,
+        name=None,
+        extra=None,
     ):
         return self.route(
             uri,
@@ -304,6 +339,7 @@ class Sanic:
             strict_slashes=strict_slashes,
             version=version,
             name=name,
+            extra=extra,
         )
 
     def add_route(
@@ -316,6 +352,7 @@ class Sanic:
         version=None,
         name=None,
         stream=False,
+        extra=None,
     ):
         """A helper method to register class instance or
         functions as a handler to the application url
@@ -362,6 +399,7 @@ class Sanic:
             stream=stream,
             version=version,
             name=name,
+            extra=extra,
         )(handler)
         return handler
 

--- a/sanic/blueprints.py
+++ b/sanic/blueprints.py
@@ -15,6 +15,7 @@ FutureRoute = namedtuple(
         "stream",
         "version",
         "name",
+        "extra",
     ],
 )
 FutureListener = namedtuple(
@@ -36,6 +37,7 @@ class Blueprint:
         url_prefix=None,
         host=None,
         version=None,
+        extra=None,
         strict_slashes=False,
     ):
         """Create a new blueprint
@@ -55,6 +57,7 @@ class Blueprint:
         self.middlewares = []
         self.statics = []
         self.version = version
+        self.extra = extra
         self.strict_slashes = strict_slashes
 
     @staticmethod
@@ -96,6 +99,7 @@ class Blueprint:
             uri = url_prefix + future.uri if url_prefix else future.uri
 
             version = future.version or self.version
+            extra = future.extra or self.extra
 
             app.route(
                 uri=uri[1:] if uri.startswith("//") else uri,
@@ -105,6 +109,7 @@ class Blueprint:
                 stream=future.stream,
                 version=version,
                 name=future.name,
+                extra=extra,
             )(future.handler)
 
         for future in self.websocket_routes:
@@ -155,6 +160,7 @@ class Blueprint:
         stream=False,
         version=None,
         name=None,
+        extra=None,
     ):
         """Create a blueprint route from a decorated function.
 
@@ -174,6 +180,7 @@ class Blueprint:
                 stream,
                 version,
                 name,
+                extra,
             )
             self.routes.append(route)
             return handler
@@ -189,6 +196,7 @@ class Blueprint:
         strict_slashes=None,
         version=None,
         name=None,
+        extra=None,
     ):
         """Create a blueprint route from a function.
 
@@ -224,6 +232,7 @@ class Blueprint:
             strict_slashes=strict_slashes,
             version=version,
             name=name,
+            extra=extra,
         )(handler)
         return handler
 
@@ -317,7 +326,13 @@ class Blueprint:
 
     # Shorthand method decorators
     def get(
-        self, uri, host=None, strict_slashes=None, version=None, name=None
+        self,
+        uri,
+        host=None,
+        strict_slashes=None,
+        version=None,
+        name=None,
+        extra=None,
     ):
         return self.route(
             uri,
@@ -326,6 +341,7 @@ class Blueprint:
             strict_slashes=strict_slashes,
             version=version,
             name=name,
+            extra=extra,
         )
 
     def post(
@@ -336,6 +352,7 @@ class Blueprint:
         stream=False,
         version=None,
         name=None,
+        extra=None,
     ):
         return self.route(
             uri,
@@ -345,6 +362,7 @@ class Blueprint:
             stream=stream,
             version=version,
             name=name,
+            extra=extra,
         )
 
     def put(
@@ -355,6 +373,7 @@ class Blueprint:
         stream=False,
         version=None,
         name=None,
+        extra=None,
     ):
         return self.route(
             uri,
@@ -364,10 +383,17 @@ class Blueprint:
             stream=stream,
             version=version,
             name=name,
+            extra=extra,
         )
 
     def head(
-        self, uri, host=None, strict_slashes=None, version=None, name=None
+        self,
+        uri,
+        host=None,
+        strict_slashes=None,
+        version=None,
+        name=None,
+        extra=None,
     ):
         return self.route(
             uri,
@@ -376,18 +402,25 @@ class Blueprint:
             strict_slashes=strict_slashes,
             version=version,
             name=name,
+            extra=extra,
         )
 
     def options(
-        self, uri, host=None, strict_slashes=None, version=None, name=None
+        self,
+        uri,
+        host=None,
+        strict_slashes=None,
+        version=None,
+        name=None,
+        extra=None,
     ):
         return self.route(
             uri,
             methods=["OPTIONS"],
             host=host,
             strict_slashes=strict_slashes,
-            version=version,
             name=name,
+            extra=extra,
         )
 
     def patch(
@@ -398,6 +431,7 @@ class Blueprint:
         stream=False,
         version=None,
         name=None,
+        extra=None,
     ):
         return self.route(
             uri,
@@ -407,10 +441,17 @@ class Blueprint:
             stream=stream,
             version=version,
             name=name,
+            extra=extra,
         )
 
     def delete(
-        self, uri, host=None, strict_slashes=None, version=None, name=None
+        self,
+        uri,
+        host=None,
+        strict_slashes=None,
+        version=None,
+        name=None,
+        extra=None,
     ):
         return self.route(
             uri,
@@ -419,4 +460,5 @@ class Blueprint:
             strict_slashes=strict_slashes,
             version=version,
             name=name,
+            extra=extra,
         )

--- a/sanic/router.py
+++ b/sanic/router.py
@@ -127,6 +127,7 @@ class Router:
         strict_slashes=False,
         version=None,
         name=None,
+        extra=None,
     ):
         """Add a handler to the route list
 


### PR DESCRIPTION
The problem that I face is the lack of route discovery information.

I would like to have an endpoint where I can see all my routes with some information like:

```json
                {
                    "scoped": ["admin"],
                    "method": "POST",
                    "description": "TODO",
                    "version": "v1",
                    "path": "/v1/api/users",
                    "body": {},
                    "responses": {201: {"users": "users"}, 401: {"TODO"}},
                },
```

But at the moment Future route has only this paramters:

```
        "handler",
        "uri",
        "methods",
        "host",
        "strict_slashes",
        "stream",
        "version",
        "name",
```

And to obtain information about a route I have an endpoint like this atm:

```python
API = Blueprint("apiv, url_prefix="/api")

@API.get("/all", version="v1", name="routes")
async def get_routes(request):

   resp = {}
    for routesin API.routes:
        resp[route.uri] = route.uri
        ....

   return response.json(resp)
```

But what is missing in my opinion is a way to retrieve information about the payload needed for a route and the response payload. Like in the json above a way of telling that the specific route needs an empty body and returns with a list of users woud be really handy for route discovery.

Maybe there is a better way to do this? But what I propose is to add a parameter in the FutureRoute called "extra" where you could be free to add information about the route, for example extra={"body": {"id": "str"}} which would mean that the route requires a json formatted payload containing a string of key "id".