### PR TITLE
Fix `remove_entity_headers` helper function

### DIFF
--- a/sanic/helpers.py
+++ b/sanic/helpers.py
@@ -128,6 +128,6 @@ def remove_entity_headers(headers, allowed=("content-location", "expires")):
     headers = {
         header: value
         for header, value in headers.items()
-        if not is_entity_header(header) and header.lower() not in allowed
+        if not is_entity_header(header) or header.lower() in allowed
     }
     return headers

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -34,3 +34,41 @@ def test_is_hop_by_hop_header():
     )
     for header, expected in tests:
         assert helpers.is_hop_by_hop_header(header) is expected
+
+
+def test_remove_entity_headers():
+    tests = (
+        (
+            {},
+            {}
+        ),
+        (
+            {
+                "Allow": "GET, POST, HEAD",
+            },
+            {}
+        ),
+        (
+            {
+                "Content-Type": "application/json",
+                "Expires": "Wed, 21 Oct 2015 07:28:00 GMT",
+                "Foo": "Bar"
+            },
+            {
+                "Expires": "Wed, 21 Oct 2015 07:28:00 GMT",
+                "Foo": "Bar"
+            },
+        ),
+        (
+            {
+                "Allow": "GET, POST, HEAD",
+                "Content-Location": "/test"
+            },
+            {
+                "Content-Location": "/test"
+            },
+        ),
+    )
+
+    for header, expected in tests:
+        assert helpers.remove_entity_headers(header) == expected


### PR DESCRIPTION
Based on the comment on `remove_entity_headers` helper function:

>  Removes all the entity headers present in the headers given.
    According to RFC 2616 Section 10.3.5,
    Content-Location and Expires are allowed as for the
    "strong cache validator".

`Content-Location` and `Expires` should be allowed.