### PR TITLE
Add in some server.py __slots__ attribute names that are missing.

### DIFF
--- a/sanic/server.py
+++ b/sanic/server.py
@@ -62,6 +62,7 @@ class HttpProtocol(asyncio.Protocol):
         "request_class",
         "is_request_stream",
         "router",
+        "error_handler",
         # enable or disable access log purpose
         "access_log",
         # connection management
@@ -73,6 +74,12 @@ class HttpProtocol(asyncio.Protocol):
         "_last_response_time",
         "_is_stream_handler",
         "_not_paused",
+        "_request_handler_task",
+        "_request_stream_task",
+        "_keep_alive",
+        "_header_fragment",
+        "state",
+        "_debug",
     )
 
     def __init__(


### PR DESCRIPTION
While doing some digging in the server.py file this morning, I found that there are a bunch of attributes used in the HTTPProtocol class which are not declared in the `__slots__` tuple at the top of the class.

Normally not having the attribute name in `__slots__` means the class cannot write to that attribute at runtime (because it doesn't exist) but in this case it never mattered because HTTPProtocol is a subclass of asyncio.Protocol, which itself is a Normal class (no `__slots__`). So having `__slots__` on the HTTPProtocol subclass to restrict its possible attributes is kind-of useless in this case because it doesn't restrict anything.

But anyway, for correctness sake this PR adds the missing attribute names to the `__slots__` of Sanic server.py HTTPProtocol.