### PR TITLE
fixed setup.py url, added vscode to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ docs/_build/
 docs/_api/
 build/*
 .DS_Store
+.vscode/

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ with open_local(['README.rst']) as rm:
 setup_kwargs = {
     'name': 'sanic',
     'version': version,
-    'url': 'http://github.com/channelcat/sanic/',
+    'url': 'http://github.com/huge-success/sanic/',
     'license': 'MIT',
     'author': 'Channel Cat',
     'author_email': 'channelcat@gmail.com',


### PR DESCRIPTION
Updated repo url inside of the `setup.py` file to point to the proper repo.

It looks like VSCode creates a local folder whenever the user manually selects an interpreter (and virtual environment so I added the folder to the `.gitignore`. Can remove if unnecessary.