### PR TITLE
Docs fix - Consistent return types in routing example

### DIFF
--- a/docs/sanic/routing.md
+++ b/docs/sanic/routing.md
@@ -10,7 +10,7 @@ from sanic.response import text
 
 @app.route("/")
 async def test(request):
-    return text('Hello World!)
+    return text('Hello World!')
 ```
 
 When the url `http://server.url/` is accessed (the base url of the server), the

--- a/docs/sanic/routing.md
+++ b/docs/sanic/routing.md
@@ -6,11 +6,11 @@ A basic route looks like the following, where `app` is an instance of the
 `Sanic` class:
 
 ```python
-from sanic.response import json
+from sanic.response import text
 
 @app.route("/")
 async def test(request):
-    return json({ "hello": "world" })
+    return text('Hello World!)
 ```
 
 When the url `http://server.url/` is accessed (the base url of the server), the


### PR DESCRIPTION
I want to expand upon this documentation in the future and have a minor section to elaborate on returning JSON vs returning a view. We can hold this PR if necessary and I can write more as I have time. This inconsistency has been crying out to me for a couple weeks. 