### PR TITLE
Fix typo in exceptions.md

### DIFF
--- a/docs/sanic/exceptions.md
+++ b/docs/sanic/exceptions.md
@@ -65,7 +65,7 @@ can subclass Sanic's default error handler as such:
 
 ```python
 from sanic import Sanic
-from sanic.handlers import ErrorHnadler
+from sanic.handlers import ErrorHandler
 
 class CustomErrorHandler(ErrorHandler):
 	def default(self, request, exception):


### PR DESCRIPTION
I found a minor typo in the official Sanic document. 
It's a code part, so it can be potentially fatal.