### PR TITLE
fix minor type and pip install instruction mismatch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ To install sanic without uvloop or ujson using bash, you can provide either or b
 using any truthy string like `'y', 'yes', 't', 'true', 'on', '1'` and setting the ``SANIC_NO_X`` (``X`` = ``UVLOOP``/``UJSON``)
 to true will stop that features installation.
 
-- ``SANIC_NO_UVLOOP=true SANIC_NO_UJSON=true pip install sanic``
+- ``SANIC_NO_UVLOOP=true SANIC_NO_UJSON=true pip3 install sanic``
 
 
 Hello World Example

--- a/docs/sanic/contributing.rst
+++ b/docs/sanic/contributing.rst
@@ -16,7 +16,7 @@ directory with a virtual environment already set up, then run:
 
 .. code:: bash
 
-   pip3 install -e . '[.dev]'
+   pip3 install -e '.[dev]'
 
 Dependency Changes
 ------------------
@@ -35,7 +35,7 @@ the document that explains the way ``sanic`` manages dependencies inside the ``s
 | extras_require['test'] | for ``sanic``                                 |                                |
 +------------------------+-----------------------------------------------+--------------------------------+
 | extras_require['dev']  | Additional Development requirements to add    | ``pip3 install -e '.[dev]'``   |
-|                        | contributing                                  |                                |
+|                        | for contributing                              |                                |
 +------------------------+-----------------------------------------------+--------------------------------+
 | extras_require['docs'] | Dependencies required to enable building and  | ``pip3 install -e '.[docs]'``  |
 |                        | enhancing sanic documentation                 |                                |


### PR DESCRIPTION
I found a couple of minor typos that got missed as part of #1424. This PR addresses those items. 