### PR TITLE
request locals

### DIFF
--- a/sanic/request.py
+++ b/sanic/request.py
@@ -89,6 +89,7 @@ class Request(dict):
         "_port",
         "__weakref__",
         "raw_url",
+        "_locals",
     )
 
     def __init__(self, url_bytes, headers, version, method, transport):
@@ -318,6 +319,12 @@ class Request(dict):
         return urlunparse(
             (self.scheme, self.host, self.path, None, self.query_string, None)
         )
+
+    @property
+    def locals(self):
+        if not hasattr(self, "_locals"):
+            self._locals = {}
+        return self._locals
 
 
 File = namedtuple("File", ["type", "body", "name"])


### PR DESCRIPTION
Based on what I get from documentation, if I want to add some data to the request object, e.g. the user that sends the request or any other info generated by a middleware, I can add it to request.headers property. However, I think this is a little bit wired because headers property is designed for another purpose. So I think request needs a dictionary to contain anything that a developer desire. The idea is based on [express.js res.locals](https://expressjs.com/en/4x/api.html#res.locals) but I suppose other async frameworks have a similar property in their request or response objects.