### PR TITLE
Fix test dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ tests_require = [
     "pytest==3.3.2",
     "multidict>=4.0,<5.0",
     "gunicorn",
-    "pytest-cov",
+    "pytest-cov==2.6.0",
     "aiohttp>=2.3.0,<=3.2.1",
     "beautifulsoup4",
     uvloop,

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ setenv =
 deps =
     coverage
     pytest==3.3.2
-    pytest-cov
+    pytest-cov==2.6.0
     pytest-sanic
     pytest-sugar
     aiohttp>=2.3,<=3.2.1


### PR DESCRIPTION
Notice Travis CI did not pass at #1457, and the reason is current version of `pytest-cov`(2.6.1) use `pytest>=3.6` in install _requires(see [here](https://github.com/pytest-dev/pytest-cov/blob/v2.6.1/setup.py#L124)). This is conflict with `Sanic`'s test_requires(it use `pytest==3.3.2`). Set `pytest-cov==2.6.0` in test_requires and tox.ini can fix this issue.

BTW, remove `pytest==3.3.2` is also a possible solution. But I don't know why use this version in test_requires, any idea?