### PR TITLE
Cold start issue

### DIFF
--- a/sanic/__init__.py
+++ b/sanic/__init__.py
@@ -1,7 +1,12 @@
-from sanic.app import Sanic
-from sanic.blueprints import Blueprint
-
-
 __version__ = "18.12.0"
 
 __all__ = ["Sanic", "Blueprint"]
+
+
+def __getattr__(name):
+    if name == "Sanic":
+        from sanic.app import Sanic
+        return Sanic
+    if name == "Blueprint":
+        from sanic.blueprints import Blueprint
+        return Blueprint

--- a/sanic/protocol.py
+++ b/sanic/protocol.py
@@ -1,0 +1,586 @@
+import asyncio
+import traceback
+
+from httptools import HttpRequestParser
+from httptools.parser.errors import HttpParserError
+from multidict import CIMultiDict
+
+from sanic.exceptions import (
+    InvalidUsage,
+    PayloadTooLarge,
+    RequestTimeout,
+    ServerError,
+    ServiceUnavailable,
+)
+from sanic.log import access_logger, logger
+from sanic.request import Request, StreamBuffer
+from sanic.response import HTTPResponse
+
+
+try:
+    import uvloop
+
+    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+except ImportError:
+    pass
+
+
+current_time = None
+
+
+class Signal:
+    stopped = False
+
+
+class HttpProtocol(asyncio.Protocol):
+    """
+    This class provides a basic HTTP implementation of the sanic framework.
+    """
+
+    __slots__ = (
+        # event loop, connection
+        "loop",
+        "transport",
+        "connections",
+        "signal",
+        # request params
+        "parser",
+        "request",
+        "url",
+        "headers",
+        # request config
+        "request_handler",
+        "request_timeout",
+        "response_timeout",
+        "keep_alive_timeout",
+        "request_max_size",
+        "request_buffer_queue_size",
+        "request_class",
+        "is_request_stream",
+        "router",
+        "error_handler",
+        # enable or disable access log purpose
+        "access_log",
+        # connection management
+        "_total_request_size",
+        "_request_timeout_handler",
+        "_response_timeout_handler",
+        "_keep_alive_timeout_handler",
+        "_last_request_time",
+        "_last_response_time",
+        "_is_stream_handler",
+        "_not_paused",
+        "_request_handler_task",
+        "_request_stream_task",
+        "_keep_alive",
+        "_header_fragment",
+        "state",
+        "_debug",
+    )
+
+    def __init__(
+        self,
+        *,
+        loop,
+        request_handler,
+        error_handler,
+        signal=Signal(),
+        connections=None,
+        request_timeout=60,
+        response_timeout=60,
+        keep_alive_timeout=5,
+        request_max_size=None,
+        request_buffer_queue_size=100,
+        request_class=None,
+        access_log=True,
+        keep_alive=True,
+        is_request_stream=False,
+        router=None,
+        state=None,
+        debug=False,
+        **kwargs
+    ):
+        self.loop = loop
+        self.transport = None
+        self.request = None
+        self.parser = None
+        self.url = None
+        self.headers = None
+        self.router = router
+        self.signal = signal
+        self.access_log = access_log
+        self.connections = connections or set()
+        self.request_handler = request_handler
+        self.error_handler = error_handler
+        self.request_timeout = request_timeout
+        self.request_buffer_queue_size = request_buffer_queue_size
+        self.response_timeout = response_timeout
+        self.keep_alive_timeout = keep_alive_timeout
+        self.request_max_size = request_max_size
+        self.request_class = request_class or Request
+        self.is_request_stream = is_request_stream
+        self._is_stream_handler = False
+        self._not_paused = asyncio.Event(loop=loop)
+        self._total_request_size = 0
+        self._request_timeout_handler = None
+        self._response_timeout_handler = None
+        self._keep_alive_timeout_handler = None
+        self._last_request_time = None
+        self._last_response_time = None
+        self._request_handler_task = None
+        self._request_stream_task = None
+        self._keep_alive = keep_alive
+        self._header_fragment = b""
+        self.state = state if state else {}
+        if "requests_count" not in self.state:
+            self.state["requests_count"] = 0
+        self._debug = debug
+        self._not_paused.set()
+
+    @property
+    def keep_alive(self):
+        """
+        Check if the connection needs to be kept alive based on the params
+        attached to the `_keep_alive` attribute, :attr:`Signal.stopped`
+        and :func:`HttpProtocol.parser.should_keep_alive`
+
+        :return: ``True`` if connection is to be kept alive ``False`` else
+        """
+        return (
+            self._keep_alive
+            and not self.signal.stopped
+            and self.parser.should_keep_alive()
+        )
+
+    # -------------------------------------------- #
+    # Connection
+    # -------------------------------------------- #
+
+    def connection_made(self, transport):
+        self.connections.add(self)
+        self._request_timeout_handler = self.loop.call_later(
+            self.request_timeout, self.request_timeout_callback
+        )
+        self.transport = transport
+        self._last_request_time = current_time
+
+    def connection_lost(self, exc):
+        self.connections.discard(self)
+        if self._request_handler_task:
+            self._request_handler_task.cancel()
+        if self._request_stream_task:
+            self._request_stream_task.cancel()
+        if self._request_timeout_handler:
+            self._request_timeout_handler.cancel()
+        if self._response_timeout_handler:
+            self._response_timeout_handler.cancel()
+        if self._keep_alive_timeout_handler:
+            self._keep_alive_timeout_handler.cancel()
+
+    def pause_writing(self):
+        self._not_paused.clear()
+
+    def resume_writing(self):
+        self._not_paused.set()
+
+    def request_timeout_callback(self):
+        # See the docstring in the RequestTimeout exception, to see
+        # exactly what this timeout is checking for.
+        # Check if elapsed time since request initiated exceeds our
+        # configured maximum request timeout value
+        time_elapsed = current_time - self._last_request_time
+        if time_elapsed < self.request_timeout:
+            time_left = self.request_timeout - time_elapsed
+            self._request_timeout_handler = self.loop.call_later(
+                time_left, self.request_timeout_callback
+            )
+        else:
+            if self._request_stream_task:
+                self._request_stream_task.cancel()
+            if self._request_handler_task:
+                self._request_handler_task.cancel()
+            self.write_error(RequestTimeout("Request Timeout"))
+
+    def response_timeout_callback(self):
+        # Check if elapsed time since response was initiated exceeds our
+        # configured maximum request timeout value
+        time_elapsed = current_time - self._last_request_time
+        if time_elapsed < self.response_timeout:
+            time_left = self.response_timeout - time_elapsed
+            self._response_timeout_handler = self.loop.call_later(
+                time_left, self.response_timeout_callback
+            )
+        else:
+            if self._request_stream_task:
+                self._request_stream_task.cancel()
+            if self._request_handler_task:
+                self._request_handler_task.cancel()
+            self.write_error(ServiceUnavailable("Response Timeout"))
+
+    def keep_alive_timeout_callback(self):
+        """
+        Check if elapsed time since last response exceeds our configured
+        maximum keep alive timeout value and if so, close the transport
+        pipe and let the response writer handle the error.
+
+        :return: None
+        """
+        time_elapsed = current_time - self._last_response_time
+        if time_elapsed < self.keep_alive_timeout:
+            time_left = self.keep_alive_timeout - time_elapsed
+            self._keep_alive_timeout_handler = self.loop.call_later(
+                time_left, self.keep_alive_timeout_callback
+            )
+        else:
+            logger.debug("KeepAlive Timeout. Closing connection.")
+            self.transport.close()
+            self.transport = None
+
+    # -------------------------------------------- #
+    # Parsing
+    # -------------------------------------------- #
+
+    def data_received(self, data):
+        # Check for the request itself getting too large and exceeding
+        # memory limits
+        self._total_request_size += len(data)
+        if self._total_request_size > self.request_max_size:
+            self.write_error(PayloadTooLarge("Payload Too Large"))
+
+        # Create parser if this is the first time we're receiving data
+        if self.parser is None:
+            assert self.request is None
+            self.headers = []
+            self.parser = HttpRequestParser(self)
+
+        # requests count
+        self.state["requests_count"] = self.state["requests_count"] + 1
+
+        # Parse request chunk or close connection
+        try:
+            self.parser.feed_data(data)
+        except HttpParserError:
+            message = "Bad Request"
+            if self._debug:
+                message += "\n" + traceback.format_exc()
+            self.write_error(InvalidUsage(message))
+
+    def on_url(self, url):
+        if not self.url:
+            self.url = url
+        else:
+            self.url += url
+
+    def on_header(self, name, value):
+        self._header_fragment += name
+
+        if value is not None:
+            if (
+                self._header_fragment == b"Content-Length"
+                and int(value) > self.request_max_size
+            ):
+                self.write_error(PayloadTooLarge("Payload Too Large"))
+            try:
+                value = value.decode()
+            except UnicodeDecodeError:
+                value = value.decode("latin_1")
+            self.headers.append(
+                (self._header_fragment.decode().casefold(), value)
+            )
+
+            self._header_fragment = b""
+
+    def on_headers_complete(self):
+        self.request = self.request_class(
+            url_bytes=self.url,
+            headers=CIMultiDict(self.headers),
+            version=self.parser.get_http_version(),
+            method=self.parser.get_method().decode(),
+            transport=self.transport,
+        )
+        # Remove any existing KeepAlive handler here,
+        # It will be recreated if required on the new request.
+        if self._keep_alive_timeout_handler:
+            self._keep_alive_timeout_handler.cancel()
+            self._keep_alive_timeout_handler = None
+        if self.is_request_stream:
+            self._is_stream_handler = self.router.is_stream_handler(
+                self.request
+            )
+            if self._is_stream_handler:
+                self.request.stream = StreamBuffer(
+                    self.request_buffer_queue_size
+                )
+                self.execute_request_handler()
+
+    def on_body(self, body):
+        if self.is_request_stream and self._is_stream_handler:
+            self._request_stream_task = self.loop.create_task(
+                self.body_append(body)
+            )
+        else:
+            self.request.body_push(body)
+
+    async def body_append(self, body):
+        if self.request.stream.is_full():
+            self.transport.pause_reading()
+            await self.request.stream.put(body)
+            self.transport.resume_reading()
+        else:
+            await self.request.stream.put(body)
+
+    def on_message_complete(self):
+        # Entire request (headers and whole body) is received.
+        # We can cancel and remove the request timeout handler now.
+        if self._request_timeout_handler:
+            self._request_timeout_handler.cancel()
+            self._request_timeout_handler = None
+        if self.is_request_stream and self._is_stream_handler:
+            self._request_stream_task = self.loop.create_task(
+                self.request.stream.put(None)
+            )
+            return
+        self.request.body_finish()
+        self.execute_request_handler()
+
+    def execute_request_handler(self):
+        """
+        Invoke the request handler defined by the
+        :func:`sanic.app.Sanic.handle_request` method
+
+        :return: None
+        """
+        self._response_timeout_handler = self.loop.call_later(
+            self.response_timeout, self.response_timeout_callback
+        )
+        self._last_request_time = current_time
+        self._request_handler_task = self.loop.create_task(
+            self.request_handler(
+                self.request, self.write_response, self.stream_response
+            )
+        )
+
+    # -------------------------------------------- #
+    # Responding
+    # -------------------------------------------- #
+    def log_response(self, response):
+        """
+        Helper method provided to enable the logging of responses in case if
+        the :attr:`HttpProtocol.access_log` is enabled.
+
+        :param response: Response generated for the current request
+
+        :type response: :class:`sanic.response.HTTPResponse` or
+            :class:`sanic.response.StreamingHTTPResponse`
+
+        :return: None
+        """
+        if self.access_log:
+            extra = {"status": getattr(response, "status", 0)}
+
+            if isinstance(response, HTTPResponse):
+                extra["byte"] = len(response.body)
+            else:
+                extra["byte"] = -1
+
+            extra["host"] = "UNKNOWN"
+            if self.request is not None:
+                if self.request.ip:
+                    extra["host"] = "{0}:{1}".format(
+                        self.request.ip, self.request.port
+                    )
+
+                extra["request"] = "{0} {1}".format(
+                    self.request.method, self.request.url
+                )
+            else:
+                extra["request"] = "nil"
+
+            access_logger.info("", extra=extra)
+
+    def write_response(self, response):
+        """
+        Writes response content synchronously to the transport.
+        """
+        if self._response_timeout_handler:
+            self._response_timeout_handler.cancel()
+            self._response_timeout_handler = None
+        try:
+            keep_alive = self.keep_alive
+            self.transport.write(
+                response.output(
+                    self.request.version, keep_alive, self.keep_alive_timeout
+                )
+            )
+            self.log_response(response)
+        except AttributeError:
+            logger.error(
+                "Invalid response object for url %s, "
+                "Expected Type: HTTPResponse, Actual Type: %s",
+                self.url,
+                type(response),
+            )
+            self.write_error(ServerError("Invalid response type"))
+        except RuntimeError:
+            if self._debug:
+                logger.error(
+                    "Connection lost before response written @ %s",
+                    self.request.ip,
+                )
+            keep_alive = False
+        except Exception as e:
+            self.bail_out(
+                "Writing response failed, connection closed {}".format(repr(e))
+            )
+        finally:
+            if not keep_alive:
+                self.transport.close()
+                self.transport = None
+            else:
+                self._keep_alive_timeout_handler = self.loop.call_later(
+                    self.keep_alive_timeout, self.keep_alive_timeout_callback
+                )
+                self._last_response_time = current_time
+                self.cleanup()
+
+    async def drain(self):
+        await self._not_paused.wait()
+
+    def push_data(self, data):
+        self.transport.write(data)
+
+    async def stream_response(self, response):
+        """
+        Streams a response to the client asynchronously. Attaches
+        the transport to the response so the response consumer can
+        write to the response as needed.
+        """
+        if self._response_timeout_handler:
+            self._response_timeout_handler.cancel()
+            self._response_timeout_handler = None
+
+        try:
+            keep_alive = self.keep_alive
+            response.protocol = self
+            await response.stream(
+                self.request.version, keep_alive, self.keep_alive_timeout
+            )
+            self.log_response(response)
+        except AttributeError:
+            logger.error(
+                "Invalid response object for url %s, "
+                "Expected Type: HTTPResponse, Actual Type: %s",
+                self.url,
+                type(response),
+            )
+            self.write_error(ServerError("Invalid response type"))
+        except RuntimeError:
+            if self._debug:
+                logger.error(
+                    "Connection lost before response written @ %s",
+                    self.request.ip,
+                )
+            keep_alive = False
+        except Exception as e:
+            self.bail_out(
+                "Writing response failed, connection closed {}".format(repr(e))
+            )
+        finally:
+            if not keep_alive:
+                self.transport.close()
+                self.transport = None
+            else:
+                self._keep_alive_timeout_handler = self.loop.call_later(
+                    self.keep_alive_timeout, self.keep_alive_timeout_callback
+                )
+                self._last_response_time = current_time
+                self.cleanup()
+
+    def write_error(self, exception):
+        # An error _is_ a response.
+        # Don't throw a response timeout, when a response _is_ given.
+        if self._response_timeout_handler:
+            self._response_timeout_handler.cancel()
+            self._response_timeout_handler = None
+        response = None
+        try:
+            response = self.error_handler.response(self.request, exception)
+            version = self.request.version if self.request else "1.1"
+            self.transport.write(response.output(version))
+        except RuntimeError:
+            if self._debug:
+                logger.error(
+                    "Connection lost before error written @ %s",
+                    self.request.ip if self.request else "Unknown",
+                )
+        except Exception as e:
+            self.bail_out(
+                "Writing error failed, connection closed {}".format(repr(e)),
+                from_error=True,
+            )
+        finally:
+            if self.parser and (
+                self.keep_alive or getattr(response, "status", 0) == 408
+            ):
+                self.log_response(response)
+            try:
+                self.transport.close()
+            except AttributeError:
+                logger.debug("Connection lost before server could close it.")
+
+    def bail_out(self, message, from_error=False):
+        """
+        In case if the transport pipes are closed and the sanic app encounters
+        an error while writing data to the transport pipe, we log the error
+        with proper details.
+
+        :param message: Error message to display
+        :param from_error: If the bail out was invoked while handling an
+            exception scenario.
+
+        :type message: str
+        :type from_error: bool
+
+        :return: None
+        """
+        if from_error or self.transport.is_closing():
+            logger.error(
+                "Transport closed @ %s and exception "
+                "experienced during error handling",
+                self.transport.get_extra_info("peername"),
+            )
+            logger.debug("Exception:", exc_info=True)
+        else:
+            self.write_error(ServerError(message))
+            logger.error(message)
+
+    def cleanup(self):
+        """This is called when KeepAlive feature is used,
+        it resets the connection in order for it to be able
+        to handle receiving another request on the same connection."""
+        self.parser = None
+        self.request = None
+        self.url = None
+        self.headers = None
+        self._request_handler_task = None
+        self._request_stream_task = None
+        self._total_request_size = 0
+        self._is_stream_handler = False
+
+    def close_if_idle(self):
+        """Close the connection if a request is not being sent or received
+
+        :return: boolean - True if closed, false if staying open
+        """
+        if not self.parser:
+            self.transport.close()
+            return True
+        return False
+
+    def close(self):
+        """
+        Force close the connection.
+        """
+        if self.transport is not None:
+            self.transport.close()
+            self.transport = None

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -1,6 +1,5 @@
 import asyncio
 import os
-import traceback
 
 from functools import partial
 from inspect import isawaitable
@@ -10,20 +9,8 @@ from signal import signal as signal_func
 from socket import SO_REUSEADDR, SOL_SOCKET, socket
 from time import time
 
-from httptools import HttpRequestParser
-from httptools.parser.errors import HttpParserError
-from multidict import CIMultiDict
-
-from sanic.exceptions import (
-    InvalidUsage,
-    PayloadTooLarge,
-    RequestTimeout,
-    ServerError,
-    ServiceUnavailable,
-)
-from sanic.log import access_logger, logger
-from sanic.request import Request, StreamBuffer
-from sanic.response import HTTPResponse
+from sanic.log import logger
+from sanic.protocol import HttpProtocol
 
 
 try:
@@ -39,560 +26,6 @@ current_time = None
 
 class Signal:
     stopped = False
-
-
-class HttpProtocol(asyncio.Protocol):
-    """
-    This class provides a basic HTTP implementation of the sanic framework.
-    """
-
-    __slots__ = (
-        # event loop, connection
-        "loop",
-        "transport",
-        "connections",
-        "signal",
-        # request params
-        "parser",
-        "request",
-        "url",
-        "headers",
-        # request config
-        "request_handler",
-        "request_timeout",
-        "response_timeout",
-        "keep_alive_timeout",
-        "request_max_size",
-        "request_buffer_queue_size",
-        "request_class",
-        "is_request_stream",
-        "router",
-        "error_handler",
-        # enable or disable access log purpose
-        "access_log",
-        # connection management
-        "_total_request_size",
-        "_request_timeout_handler",
-        "_response_timeout_handler",
-        "_keep_alive_timeout_handler",
-        "_last_request_time",
-        "_last_response_time",
-        "_is_stream_handler",
-        "_not_paused",
-        "_request_handler_task",
-        "_request_stream_task",
-        "_keep_alive",
-        "_header_fragment",
-        "state",
-        "_debug",
-    )
-
-    def __init__(
-        self,
-        *,
-        loop,
-        request_handler,
-        error_handler,
-        signal=Signal(),
-        connections=None,
-        request_timeout=60,
-        response_timeout=60,
-        keep_alive_timeout=5,
-        request_max_size=None,
-        request_buffer_queue_size=100,
-        request_class=None,
-        access_log=True,
-        keep_alive=True,
-        is_request_stream=False,
-        router=None,
-        state=None,
-        debug=False,
-        **kwargs
-    ):
-        self.loop = loop
-        self.transport = None
-        self.request = None
-        self.parser = None
-        self.url = None
-        self.headers = None
-        self.router = router
-        self.signal = signal
-        self.access_log = access_log
-        self.connections = connections or set()
-        self.request_handler = request_handler
-        self.error_handler = error_handler
-        self.request_timeout = request_timeout
-        self.request_buffer_queue_size = request_buffer_queue_size
-        self.response_timeout = response_timeout
-        self.keep_alive_timeout = keep_alive_timeout
-        self.request_max_size = request_max_size
-        self.request_class = request_class or Request
-        self.is_request_stream = is_request_stream
-        self._is_stream_handler = False
-        self._not_paused = asyncio.Event(loop=loop)
-        self._total_request_size = 0
-        self._request_timeout_handler = None
-        self._response_timeout_handler = None
-        self._keep_alive_timeout_handler = None
-        self._last_request_time = None
-        self._last_response_time = None
-        self._request_handler_task = None
-        self._request_stream_task = None
-        self._keep_alive = keep_alive
-        self._header_fragment = b""
-        self.state = state if state else {}
-        if "requests_count" not in self.state:
-            self.state["requests_count"] = 0
-        self._debug = debug
-        self._not_paused.set()
-
-    @property
-    def keep_alive(self):
-        """
-        Check if the connection needs to be kept alive based on the params
-        attached to the `_keep_alive` attribute, :attr:`Signal.stopped`
-        and :func:`HttpProtocol.parser.should_keep_alive`
-
-        :return: ``True`` if connection is to be kept alive ``False`` else
-        """
-        return (
-            self._keep_alive
-            and not self.signal.stopped
-            and self.parser.should_keep_alive()
-        )
-
-    # -------------------------------------------- #
-    # Connection
-    # -------------------------------------------- #
-
-    def connection_made(self, transport):
-        self.connections.add(self)
-        self._request_timeout_handler = self.loop.call_later(
-            self.request_timeout, self.request_timeout_callback
-        )
-        self.transport = transport
-        self._last_request_time = current_time
-
-    def connection_lost(self, exc):
-        self.connections.discard(self)
-        if self._request_handler_task:
-            self._request_handler_task.cancel()
-        if self._request_stream_task:
-            self._request_stream_task.cancel()
-        if self._request_timeout_handler:
-            self._request_timeout_handler.cancel()
-        if self._response_timeout_handler:
-            self._response_timeout_handler.cancel()
-        if self._keep_alive_timeout_handler:
-            self._keep_alive_timeout_handler.cancel()
-
-    def pause_writing(self):
-        self._not_paused.clear()
-
-    def resume_writing(self):
-        self._not_paused.set()
-
-    def request_timeout_callback(self):
-        # See the docstring in the RequestTimeout exception, to see
-        # exactly what this timeout is checking for.
-        # Check if elapsed time since request initiated exceeds our
-        # configured maximum request timeout value
-        time_elapsed = current_time - self._last_request_time
-        if time_elapsed < self.request_timeout:
-            time_left = self.request_timeout - time_elapsed
-            self._request_timeout_handler = self.loop.call_later(
-                time_left, self.request_timeout_callback
-            )
-        else:
-            if self._request_stream_task:
-                self._request_stream_task.cancel()
-            if self._request_handler_task:
-                self._request_handler_task.cancel()
-            self.write_error(RequestTimeout("Request Timeout"))
-
-    def response_timeout_callback(self):
-        # Check if elapsed time since response was initiated exceeds our
-        # configured maximum request timeout value
-        time_elapsed = current_time - self._last_request_time
-        if time_elapsed < self.response_timeout:
-            time_left = self.response_timeout - time_elapsed
-            self._response_timeout_handler = self.loop.call_later(
-                time_left, self.response_timeout_callback
-            )
-        else:
-            if self._request_stream_task:
-                self._request_stream_task.cancel()
-            if self._request_handler_task:
-                self._request_handler_task.cancel()
-            self.write_error(ServiceUnavailable("Response Timeout"))
-
-    def keep_alive_timeout_callback(self):
-        """
-        Check if elapsed time since last response exceeds our configured
-        maximum keep alive timeout value and if so, close the transport
-        pipe and let the response writer handle the error.
-
-        :return: None
-        """
-        time_elapsed = current_time - self._last_response_time
-        if time_elapsed < self.keep_alive_timeout:
-            time_left = self.keep_alive_timeout - time_elapsed
-            self._keep_alive_timeout_handler = self.loop.call_later(
-                time_left, self.keep_alive_timeout_callback
-            )
-        else:
-            logger.debug("KeepAlive Timeout. Closing connection.")
-            self.transport.close()
-            self.transport = None
-
-    # -------------------------------------------- #
-    # Parsing
-    # -------------------------------------------- #
-
-    def data_received(self, data):
-        # Check for the request itself getting too large and exceeding
-        # memory limits
-        self._total_request_size += len(data)
-        if self._total_request_size > self.request_max_size:
-            self.write_error(PayloadTooLarge("Payload Too Large"))
-
-        # Create parser if this is the first time we're receiving data
-        if self.parser is None:
-            assert self.request is None
-            self.headers = []
-            self.parser = HttpRequestParser(self)
-
-        # requests count
-        self.state["requests_count"] = self.state["requests_count"] + 1
-
-        # Parse request chunk or close connection
-        try:
-            self.parser.feed_data(data)
-        except HttpParserError:
-            message = "Bad Request"
-            if self._debug:
-                message += "\n" + traceback.format_exc()
-            self.write_error(InvalidUsage(message))
-
-    def on_url(self, url):
-        if not self.url:
-            self.url = url
-        else:
-            self.url += url
-
-    def on_header(self, name, value):
-        self._header_fragment += name
-
-        if value is not None:
-            if (
-                self._header_fragment == b"Content-Length"
-                and int(value) > self.request_max_size
-            ):
-                self.write_error(PayloadTooLarge("Payload Too Large"))
-            try:
-                value = value.decode()
-            except UnicodeDecodeError:
-                value = value.decode("latin_1")
-            self.headers.append(
-                (self._header_fragment.decode().casefold(), value)
-            )
-
-            self._header_fragment = b""
-
-    def on_headers_complete(self):
-        self.request = self.request_class(
-            url_bytes=self.url,
-            headers=CIMultiDict(self.headers),
-            version=self.parser.get_http_version(),
-            method=self.parser.get_method().decode(),
-            transport=self.transport,
-        )
-        # Remove any existing KeepAlive handler here,
-        # It will be recreated if required on the new request.
-        if self._keep_alive_timeout_handler:
-            self._keep_alive_timeout_handler.cancel()
-            self._keep_alive_timeout_handler = None
-        if self.is_request_stream:
-            self._is_stream_handler = self.router.is_stream_handler(
-                self.request
-            )
-            if self._is_stream_handler:
-                self.request.stream = StreamBuffer(
-                    self.request_buffer_queue_size
-                )
-                self.execute_request_handler()
-
-    def on_body(self, body):
-        if self.is_request_stream and self._is_stream_handler:
-            self._request_stream_task = self.loop.create_task(
-                self.body_append(body)
-            )
-        else:
-            self.request.body_push(body)
-
-    async def body_append(self, body):
-        if self.request.stream.is_full():
-            self.transport.pause_reading()
-            await self.request.stream.put(body)
-            self.transport.resume_reading()
-        else:
-            await self.request.stream.put(body)
-
-    def on_message_complete(self):
-        # Entire request (headers and whole body) is received.
-        # We can cancel and remove the request timeout handler now.
-        if self._request_timeout_handler:
-            self._request_timeout_handler.cancel()
-            self._request_timeout_handler = None
-        if self.is_request_stream and self._is_stream_handler:
-            self._request_stream_task = self.loop.create_task(
-                self.request.stream.put(None)
-            )
-            return
-        self.request.body_finish()
-        self.execute_request_handler()
-
-    def execute_request_handler(self):
-        """
-        Invoke the request handler defined by the
-        :func:`sanic.app.Sanic.handle_request` method
-
-        :return: None
-        """
-        self._response_timeout_handler = self.loop.call_later(
-            self.response_timeout, self.response_timeout_callback
-        )
-        self._last_request_time = current_time
-        self._request_handler_task = self.loop.create_task(
-            self.request_handler(
-                self.request, self.write_response, self.stream_response
-            )
-        )
-
-    # -------------------------------------------- #
-    # Responding
-    # -------------------------------------------- #
-    def log_response(self, response):
-        """
-        Helper method provided to enable the logging of responses in case if
-        the :attr:`HttpProtocol.access_log` is enabled.
-
-        :param response: Response generated for the current request
-
-        :type response: :class:`sanic.response.HTTPResponse` or
-            :class:`sanic.response.StreamingHTTPResponse`
-
-        :return: None
-        """
-        if self.access_log:
-            extra = {"status": getattr(response, "status", 0)}
-
-            if isinstance(response, HTTPResponse):
-                extra["byte"] = len(response.body)
-            else:
-                extra["byte"] = -1
-
-            extra["host"] = "UNKNOWN"
-            if self.request is not None:
-                if self.request.ip:
-                    extra["host"] = "{0}:{1}".format(
-                        self.request.ip, self.request.port
-                    )
-
-                extra["request"] = "{0} {1}".format(
-                    self.request.method, self.request.url
-                )
-            else:
-                extra["request"] = "nil"
-
-            access_logger.info("", extra=extra)
-
-    def write_response(self, response):
-        """
-        Writes response content synchronously to the transport.
-        """
-        if self._response_timeout_handler:
-            self._response_timeout_handler.cancel()
-            self._response_timeout_handler = None
-        try:
-            keep_alive = self.keep_alive
-            self.transport.write(
-                response.output(
-                    self.request.version, keep_alive, self.keep_alive_timeout
-                )
-            )
-            self.log_response(response)
-        except AttributeError:
-            logger.error(
-                "Invalid response object for url %s, "
-                "Expected Type: HTTPResponse, Actual Type: %s",
-                self.url,
-                type(response),
-            )
-            self.write_error(ServerError("Invalid response type"))
-        except RuntimeError:
-            if self._debug:
-                logger.error(
-                    "Connection lost before response written @ %s",
-                    self.request.ip,
-                )
-            keep_alive = False
-        except Exception as e:
-            self.bail_out(
-                "Writing response failed, connection closed {}".format(repr(e))
-            )
-        finally:
-            if not keep_alive:
-                self.transport.close()
-                self.transport = None
-            else:
-                self._keep_alive_timeout_handler = self.loop.call_later(
-                    self.keep_alive_timeout, self.keep_alive_timeout_callback
-                )
-                self._last_response_time = current_time
-                self.cleanup()
-
-    async def drain(self):
-        await self._not_paused.wait()
-
-    def push_data(self, data):
-        self.transport.write(data)
-
-    async def stream_response(self, response):
-        """
-        Streams a response to the client asynchronously. Attaches
-        the transport to the response so the response consumer can
-        write to the response as needed.
-        """
-        if self._response_timeout_handler:
-            self._response_timeout_handler.cancel()
-            self._response_timeout_handler = None
-
-        try:
-            keep_alive = self.keep_alive
-            response.protocol = self
-            await response.stream(
-                self.request.version, keep_alive, self.keep_alive_timeout
-            )
-            self.log_response(response)
-        except AttributeError:
-            logger.error(
-                "Invalid response object for url %s, "
-                "Expected Type: HTTPResponse, Actual Type: %s",
-                self.url,
-                type(response),
-            )
-            self.write_error(ServerError("Invalid response type"))
-        except RuntimeError:
-            if self._debug:
-                logger.error(
-                    "Connection lost before response written @ %s",
-                    self.request.ip,
-                )
-            keep_alive = False
-        except Exception as e:
-            self.bail_out(
-                "Writing response failed, connection closed {}".format(repr(e))
-            )
-        finally:
-            if not keep_alive:
-                self.transport.close()
-                self.transport = None
-            else:
-                self._keep_alive_timeout_handler = self.loop.call_later(
-                    self.keep_alive_timeout, self.keep_alive_timeout_callback
-                )
-                self._last_response_time = current_time
-                self.cleanup()
-
-    def write_error(self, exception):
-        # An error _is_ a response.
-        # Don't throw a response timeout, when a response _is_ given.
-        if self._response_timeout_handler:
-            self._response_timeout_handler.cancel()
-            self._response_timeout_handler = None
-        response = None
-        try:
-            response = self.error_handler.response(self.request, exception)
-            version = self.request.version if self.request else "1.1"
-            self.transport.write(response.output(version))
-        except RuntimeError:
-            if self._debug:
-                logger.error(
-                    "Connection lost before error written @ %s",
-                    self.request.ip if self.request else "Unknown",
-                )
-        except Exception as e:
-            self.bail_out(
-                "Writing error failed, connection closed {}".format(repr(e)),
-                from_error=True,
-            )
-        finally:
-            if self.parser and (
-                self.keep_alive or getattr(response, "status", 0) == 408
-            ):
-                self.log_response(response)
-            try:
-                self.transport.close()
-            except AttributeError:
-                logger.debug("Connection lost before server could close it.")
-
-    def bail_out(self, message, from_error=False):
-        """
-        In case if the transport pipes are closed and the sanic app encounters
-        an error while writing data to the transport pipe, we log the error
-        with proper details.
-
-        :param message: Error message to display
-        :param from_error: If the bail out was invoked while handling an
-            exception scenario.
-
-        :type message: str
-        :type from_error: bool
-
-        :return: None
-        """
-        if from_error or self.transport.is_closing():
-            logger.error(
-                "Transport closed @ %s and exception "
-                "experienced during error handling",
-                self.transport.get_extra_info("peername"),
-            )
-            logger.debug("Exception:", exc_info=True)
-        else:
-            self.write_error(ServerError(message))
-            logger.error(message)
-
-    def cleanup(self):
-        """This is called when KeepAlive feature is used,
-        it resets the connection in order for it to be able
-        to handle receiving another request on the same connection."""
-        self.parser = None
-        self.request = None
-        self.url = None
-        self.headers = None
-        self._request_handler_task = None
-        self._request_stream_task = None
-        self._total_request_size = 0
-        self._is_stream_handler = False
-
-    def close_if_idle(self):
-        """Close the connection if a request is not being sent or received
-
-        :return: boolean - True if closed, false if staying open
-        """
-        if not self.parser:
-            self.transport.close()
-            return True
-        return False
-
-    def close(self):
-        """
-        Force close the connection.
-        """
-        if self.transport is not None:
-            self.transport.close()
-            self.transport = None
 
 
 def update_current_time(loop):
@@ -617,6 +50,124 @@ def trigger_events(events, loop):
         result = event(loop)
         if isawaitable(result):
             loop.run_until_complete(result)
+
+
+def create_server(
+    host,
+    port,
+    request_handler,
+    error_handler,
+    before_start=None,
+    after_start=None,
+    before_stop=None,
+    after_stop=None,
+    debug=False,
+    request_timeout=60,
+    response_timeout=60,
+    keep_alive_timeout=5,
+    ssl=None,
+    sock=None,
+    request_max_size=None,
+    request_buffer_queue_size=100,
+    reuse_port=False,
+    loop=None,
+    protocol=HttpProtocol,
+    backlog=100,
+    register_sys_signals=True,
+    run_multiple=False,
+    run_async=False,
+    connections=None,
+    signal=Signal(),
+    request_class=None,
+    access_log=True,
+    keep_alive=True,
+    is_request_stream=False,
+    router=None,
+    websocket_max_size=None,
+    websocket_max_queue=None,
+    websocket_read_limit=2 ** 16,
+    websocket_write_limit=2 ** 16,
+    state=None,
+    server_kwargs=None,
+):
+    if not run_async:
+        # create new event_loop after fork
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+    if debug:
+        loop.set_debug(debug)
+
+    connections = connections if connections is not None else set()
+    server = partial(
+        protocol,
+        loop=loop,
+        connections=connections,
+        signal=signal,
+        request_handler=request_handler,
+        error_handler=error_handler,
+        request_timeout=request_timeout,
+        response_timeout=response_timeout,
+        keep_alive_timeout=keep_alive_timeout,
+        request_max_size=request_max_size,
+        request_class=request_class,
+        access_log=access_log,
+        keep_alive=keep_alive,
+        is_request_stream=is_request_stream,
+        router=router,
+        websocket_max_size=websocket_max_size,
+        websocket_max_queue=websocket_max_queue,
+        websocket_read_limit=websocket_read_limit,
+        websocket_write_limit=websocket_write_limit,
+        state=state,
+        debug=debug,
+    )
+    server_kwargs = server_kwargs if server_kwargs else {}
+    server_coroutine = loop.create_server(
+        server,
+        host,
+        port,
+        ssl=ssl,
+        reuse_port=reuse_port,
+        sock=sock,
+        backlog=backlog,
+        **server_kwargs
+    )
+
+    # Instead of pulling time at the end of every request,
+    # pull it once per minute
+    loop.call_soon(partial(update_current_time, loop))
+
+    if run_async:
+        return server_coroutine
+
+    trigger_events(before_start, loop)
+
+    try:
+        http_server = loop.run_until_complete(server_coroutine)
+    except BaseException:
+        logger.exception("Unable to start server")
+        return
+
+    trigger_events(after_start, loop)
+
+    # Ignore SIGINT when run_multiple
+    if run_multiple:
+        signal_func(SIGINT, SIG_IGN)
+
+    # Register signals for graceful termination
+    if register_sys_signals:
+        _singals = (SIGTERM,) if run_multiple else (SIGINT, SIGTERM)
+        for _signal in _singals:
+            try:
+                loop.add_signal_handler(_signal, loop.stop)
+            except NotImplementedError:
+                logger.warning(
+                    "Sanic tried to use loop.add_signal_handler "
+                    "but it is not implemented on this platform."
+                )
+
+    return http_server
 
 
 def serve(
@@ -784,42 +335,54 @@ def serve(
     finally:
         logger.info("Stopping worker [%s]", pid)
 
-        # Run the on_stop function if provided
-        trigger_events(before_stop, loop)
+        stop_server(
+            http_server,
+            connections=connections,
+            signal=signal,
+            before_stop=before_stop,
+            after_stop=after_stop,
+            graceful_shutdown_timeout=graceful_shutdown_timeout,
+        )
 
-        # Wait for event loop to finish and all connections to drain
-        http_server.close()
-        loop.run_until_complete(http_server.wait_closed())
 
-        # Complete all tasks on the loop
-        signal.stopped = True
-        for connection in connections:
-            connection.close_if_idle()
+def stop_server(http_server, connections=None, signal=Signal(),
+                before_stop=None, after_stop=None,
+                loop=None, graceful_shutdown_timeout=15.0):
+    trigger_events(before_stop, loop)
 
-        # Gracefully shutdown timeout.
-        # We should provide graceful_shutdown_timeout,
-        # instead of letting connection hangs forever.
-        # Let's roughly calcucate time.
-        start_shutdown = 0
-        while connections and (start_shutdown < graceful_shutdown_timeout):
-            loop.run_until_complete(asyncio.sleep(0.1))
-            start_shutdown = start_shutdown + 0.1
+    # Wait for event loop to finish and all connections to drain
+    http_server.close()
+    loop.run_until_complete(http_server.wait_closed())
 
-        # Force close non-idle connection after waiting for
-        # graceful_shutdown_timeout
-        coros = []
-        for conn in connections:
-            if hasattr(conn, "websocket") and conn.websocket:
-                coros.append(conn.websocket.close_connection())
-            else:
-                conn.close()
+    # Complete all tasks on the loop
+    signal.stopped = True
+    for connection in connections:
+        connection.close_if_idle()
 
-        _shutdown = asyncio.gather(*coros, loop=loop)
-        loop.run_until_complete(_shutdown)
+    # Gracefully shutdown timeout.
+    # We should provide graceful_shutdown_timeout,
+    # instead of letting connection hangs forever.
+    # Let's roughly calcucate time.
+    start_shutdown = 0
+    while connections and (start_shutdown < graceful_shutdown_timeout):
+        loop.run_until_complete(asyncio.sleep(0.1))
+        start_shutdown = start_shutdown + 0.1
 
-        trigger_events(after_stop, loop)
+    # Force close non-idle connection after waiting for
+    # graceful_shutdown_timeout
+    coros = []
+    for conn in connections:
+        if hasattr(conn, "websocket") and conn.websocket:
+            coros.append(conn.websocket.close_connection())
+        else:
+            conn.close()
 
-        loop.close()
+    _shutdown = asyncio.gather(*coros, loop=loop)
+    loop.run_until_complete(_shutdown)
+
+    trigger_events(after_stop, loop)
+
+    loop.close()
 
 
 def serve_multiple(server_settings, workers):

--- a/sanic/websocket.py
+++ b/sanic/websocket.py
@@ -1,105 +1,112 @@
-from httptools import HttpParserUpgrade
-from websockets import ConnectionClosed  # noqa
-from websockets import InvalidHandshake, WebSocketCommonProtocol, handshake
+def ___import_websocket():
+    from httptools import HttpParserUpgrade
+    from websockets import WebSocketCommonProtocol, handshake
 
-from sanic.exceptions import InvalidUsage
-from sanic.server import HttpProtocol
+    from sanic.exceptions import InvalidUsage
+    from sanic.websocket_exceptions import InvalidHandshake
+    from sanic.server import HttpProtocol
 
+    class WebSocketProtocol(HttpProtocol):
+        def __init__(
+                self,
+                *args,
+                websocket_timeout=10,
+                websocket_max_size=None,
+                websocket_max_queue=None,
+                websocket_read_limit=2 ** 16,
+                websocket_write_limit=2 ** 16,
+                **kwargs
+        ):
+            super().__init__(*args, **kwargs)
+            self.websocket = None
+            self.websocket_timeout = websocket_timeout
+            self.websocket_max_size = websocket_max_size
+            self.websocket_max_queue = websocket_max_queue
+            self.websocket_read_limit = websocket_read_limit
+            self.websocket_write_limit = websocket_write_limit
 
-class WebSocketProtocol(HttpProtocol):
-    def __init__(
-        self,
-        *args,
-        websocket_timeout=10,
-        websocket_max_size=None,
-        websocket_max_queue=None,
-        websocket_read_limit=2 ** 16,
-        websocket_write_limit=2 ** 16,
-        **kwargs
-    ):
-        super().__init__(*args, **kwargs)
-        self.websocket = None
-        self.websocket_timeout = websocket_timeout
-        self.websocket_max_size = websocket_max_size
-        self.websocket_max_queue = websocket_max_queue
-        self.websocket_read_limit = websocket_read_limit
-        self.websocket_write_limit = websocket_write_limit
+        # timeouts make no sense for websocket routes
+        def request_timeout_callback(self):
+            if self.websocket is None:
+                super().request_timeout_callback()
 
-    # timeouts make no sense for websocket routes
-    def request_timeout_callback(self):
-        if self.websocket is None:
-            super().request_timeout_callback()
+        def response_timeout_callback(self):
+            if self.websocket is None:
+                super().response_timeout_callback()
 
-    def response_timeout_callback(self):
-        if self.websocket is None:
-            super().response_timeout_callback()
+        def keep_alive_timeout_callback(self):
+            if self.websocket is None:
+                super().keep_alive_timeout_callback()
 
-    def keep_alive_timeout_callback(self):
-        if self.websocket is None:
-            super().keep_alive_timeout_callback()
+        def connection_lost(self, exc):
+            if self.websocket is not None:
+                self.websocket.connection_lost(exc)
+            super().connection_lost(exc)
 
-    def connection_lost(self, exc):
-        if self.websocket is not None:
-            self.websocket.connection_lost(exc)
-        super().connection_lost(exc)
+        def data_received(self, data):
+            if self.websocket is not None:
+                # pass the data to the websocket protocol
+                self.websocket.data_received(data)
+            else:
+                try:
+                    super().data_received(data)
+                except HttpParserUpgrade:
+                    # this is okay, it just indicates we've got an upgrade request
+                    pass
 
-    def data_received(self, data):
-        if self.websocket is not None:
-            # pass the data to the websocket protocol
-            self.websocket.data_received(data)
-        else:
+        def write_response(self, response):
+            if self.websocket is not None:
+                # websocket requests do not write a response
+                self.transport.close()
+            else:
+                super().write_response(response)
+
+        async def websocket_handshake(self, request, subprotocols=None):
+            # let the websockets package do the handshake with the client
+            headers = {}
+
             try:
-                super().data_received(data)
-            except HttpParserUpgrade:
-                # this is okay, it just indicates we've got an upgrade request
-                pass
+                key = handshake.check_request(request.headers)
+                handshake.build_response(headers, key)
+            except InvalidHandshake:
+                raise InvalidUsage("Invalid websocket request")
 
-    def write_response(self, response):
-        if self.websocket is not None:
-            # websocket requests do not write a response
-            self.transport.close()
-        else:
-            super().write_response(response)
+            subprotocol = None
+            if subprotocols and "Sec-Websocket-Protocol" in request.headers:
+                # select a subprotocol
+                client_subprotocols = [
+                    p.strip()
+                    for p in request.headers["Sec-Websocket-Protocol"].split(",")
+                ]
+                for p in client_subprotocols:
+                    if p in subprotocols:
+                        subprotocol = p
+                        headers["Sec-Websocket-Protocol"] = subprotocol
+                        break
 
-    async def websocket_handshake(self, request, subprotocols=None):
-        # let the websockets package do the handshake with the client
-        headers = {}
+            # write the 101 response back to the client
+            rv = b"HTTP/1.1 101 Switching Protocols\r\n"
+            for k, v in headers.items():
+                rv += k.encode("utf-8") + b": " + v.encode("utf-8") + b"\r\n"
+            rv += b"\r\n"
+            request.transport.write(rv)
 
-        try:
-            key = handshake.check_request(request.headers)
-            handshake.build_response(headers, key)
-        except InvalidHandshake:
-            raise InvalidUsage("Invalid websocket request")
+            # hook up the websocket protocol
+            self.websocket = WebSocketCommonProtocol(
+                timeout=self.websocket_timeout,
+                max_size=self.websocket_max_size,
+                max_queue=self.websocket_max_queue,
+                read_limit=self.websocket_read_limit,
+                write_limit=self.websocket_write_limit,
+            )
+            self.websocket.subprotocol = subprotocol
+            self.websocket.connection_made(request.transport)
+            self.websocket.connection_open()
+            return self.websocket
 
-        subprotocol = None
-        if subprotocols and "Sec-Websocket-Protocol" in request.headers:
-            # select a subprotocol
-            client_subprotocols = [
-                p.strip()
-                for p in request.headers["Sec-Websocket-Protocol"].split(",")
-            ]
-            for p in client_subprotocols:
-                if p in subprotocols:
-                    subprotocol = p
-                    headers["Sec-Websocket-Protocol"] = subprotocol
-                    break
+    return WebSocketProtocol
 
-        # write the 101 response back to the client
-        rv = b"HTTP/1.1 101 Switching Protocols\r\n"
-        for k, v in headers.items():
-            rv += k.encode("utf-8") + b": " + v.encode("utf-8") + b"\r\n"
-        rv += b"\r\n"
-        request.transport.write(rv)
 
-        # hook up the websocket protocol
-        self.websocket = WebSocketCommonProtocol(
-            timeout=self.websocket_timeout,
-            max_size=self.websocket_max_size,
-            max_queue=self.websocket_max_queue,
-            read_limit=self.websocket_read_limit,
-            write_limit=self.websocket_write_limit,
-        )
-        self.websocket.subprotocol = subprotocol
-        self.websocket.connection_made(request.transport)
-        self.websocket.connection_open()
-        return self.websocket
+def __getattr__(name):
+    if name == "WebSocketProtocol":
+        return ___import_websocket()

--- a/sanic/websocket_exceptions.py
+++ b/sanic/websocket_exceptions.py
@@ -1,0 +1,10 @@
+__all__ = ["ConnectionClosed", "InvalidHandshake"]
+
+
+def __getattr__(name):
+    if name == "ConnectionClosed":
+        from websockets import ConnectionClosed
+        return ConnectionClosed
+    if name == "InvalidHandshake":
+        from websockets import InvalidHandshake
+        return InvalidHandshake


### PR DESCRIPTION
# Intro
 
In Serverless Fn Project we use UNIX sockets to ship requests to functions,
 at function side, we have an FDK (function development kit),
 for an HTTP trigger, we use an HTTP server over UNIX socket.

# Problem area

 The problem is a cold start thing: we need an HTTP server to start within 3 seconds on 128Mb RAM.
 AIOHTTP takes almost 10 seconds to start, but Sanic can do that faster - 6 seconds.

# Improvement

 With some importing tweaks, I was able to go low up to 1.5-2 seconds with no harm to the rest of API.

 # Side change

 uvloop is quite outdated and doesn't support Python 3.7, specifically "start_serving=True",
 we need this feature in order to do some manipulations with Unix socket between the following stages:
 - server created, but not started
 - server can be started using "*.start_serving()"
 - a server can be started in an infinite loop with "*.serve_forever()"

 unfortunately, Sanic's app method "create_server" doesn't actually create a server,
 but make it start serving right away.

 so, this side change introduces a new method "sanic.server.create_server" that will create an instance of asyncio server.
 this new method is compatible with both uvloop and asyncio event loop.

 "sanic.app.Sanic.create_server" is also changed in order to work with "sanic.server.create_server"

Closes: #1466 
