### PR TITLE
add Request.not_grouped_args, deprecation warning Request.raw_args

### DIFF
--- a/docs/sanic/request_data.md
+++ b/docs/sanic/request_data.md
@@ -28,9 +28,11 @@ The following variables are accessible as properties on `Request` objects:
       return json({ "parsed": True, "args": request.args, "url": request.url, "query_string": request.query_string })
   ```
 
-- `raw_args` (dict) - On many cases you would need to access the url arguments in
-  a less packed dictionary. For same previous URL `?key1=value1&key2=value2`, the
-  `raw_args` dictionary would look like `{'key1': 'value1', 'key2': 'value2'}`.
+- `not_grouped_args` (list) - On many cases you would need to access the url arguments in
+  a less packed form. For same previous URL `?key1=value1&key2=value2`, the
+  `not_grouped_args` list would look like `[('key1', 'value1'), ('key2', 'value2')]`.
+  And in case of the multiple params with the same key like `?key1=value1&key2=value2&key1=value3`
+  the `not_grouped_args` list would look like `[('key1', 'value1'), ('key2', 'value2'), ('key1', 'value3')]`.
 
 - `files` (dictionary of `File` objects) - List of files that have a name, body, and type
 

--- a/docs/sanic/request_data.md
+++ b/docs/sanic/request_data.md
@@ -157,7 +157,7 @@ The following variables are accessible as properties on `Request` objects:
 
 The default parameters that are using internally in `args` and `query_args` properties to parse queryset:
 
-- `keep_blank_values` (bool): `True` - flag indicating whether blank values in
+- `keep_blank_values` (bool): `False` - flag indicating whether blank values in
   percent-encoded queries should be treated as blank strings.
   A true value indicates that blanks should be retained as blank
   strings.  The default false value indicates that blank values
@@ -169,17 +169,34 @@ The default parameters that are using internally in `args` and `query_args` prop
   into Unicode characters, as accepted by the bytes.decode() method.
 
 If you would like to change that default parameters you could call `get_args` and `get_query_args` methods
-with new values.
+with the new values.
+
+For the queryset `/?test1=value1&test2=&test3=value3`:
 
 ```python
 from sanic.response import json
 
 @app.route("/query_string")
 def query_string(request):
-
-    return json({ "parsed": True, "args": request.args, "url": request.url, "query_string": request.query_string })
+    args_with_blank_values = request.get_args(keep_blank_values=True)
+    return json({
+        "parsed": True,
+        "url": request.url,
+        "args_with_blank_values": args_with_blank_values,
+        "query_string": request.query_string
+    })
 ```
 
+The output will be:
+
+```
+{
+    "parsed": true,
+    "url": "http:\/\/0.0.0.0:8000\/query_string?test1=value1&test2=&test3=value3",
+    "args_with_blank_values": {"test1": ["value1""], "test2": "", "test3": ["value3"]},
+    "query_string": "test1=value1&test2=&test3=value3"
+}
+```
 
 ## Accessing values using `get` and `getlist`
 

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -210,6 +210,28 @@ class Request(dict):
         encoding: str = "utf-8",
         errors: str = "replace",
     ) -> RequestParameters:
+        """
+        Method to parse `query_string` using `urllib.parse.parse_qs`.
+        This methods is used by `args` property.
+        Can be used directly if you need to change default parameters.
+        :param keep_blank_values: flag indicating whether blank values in
+            percent-encoded queries should be treated as blank strings.
+            A true value indicates that blanks should be retained as blank
+            strings.  The default false value indicates that blank values
+            are to be ignored and treated as if they were  not included.
+        :type keep_blank_values: bool
+        :param strict_parsing: flag indicating what to do with parsing errors.
+            If false (the default), errors are silently ignored. If true,
+            errors raise a ValueError exception.
+        :type strict_parsing: bool
+        :param encoding: specify how to decode percent-encoded sequences
+            into Unicode characters, as accepted by the bytes.decode() method.
+        :type encoding: str
+        :param errors: specify how to decode percent-encoded sequences
+            into Unicode characters, as accepted by the bytes.decode() method.
+        :type errors: str
+        :return: RequestParameters
+        """
         if not self.parsed_args[
             (keep_blank_values, strict_parsing, encoding, errors)
         ]:
@@ -251,6 +273,28 @@ class Request(dict):
         encoding: str = "utf-8",
         errors: str = "replace",
     ) -> list:
+        """
+        Method to parse `query_string` using `urllib.parse.parse_qsl`.
+        This methods is used by `query_args` property.
+        Can be used directly if you need to change default parameters.
+        :param keep_blank_values: flag indicating whether blank values in
+            percent-encoded queries should be treated as blank strings.
+            A true value indicates that blanks should be retained as blank
+            strings.  The default false value indicates that blank values
+            are to be ignored and treated as if they were  not included.
+        :type keep_blank_values: bool
+        :param strict_parsing: flag indicating what to do with parsing errors.
+            If false (the default), errors are silently ignored. If true,
+            errors raise a ValueError exception.
+        :type strict_parsing: bool
+        :param encoding: specify how to decode percent-encoded sequences
+            into Unicode characters, as accepted by the bytes.decode() method.
+        :type encoding: str
+        :param errors: specify how to decode percent-encoded sequences
+            into Unicode characters, as accepted by the bytes.decode() method.
+        :type errors: str
+        :return: list
+        """
         if not self.parsed_not_grouped_args[
             (keep_blank_values, strict_parsing, encoding, errors)
         ]:

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -7,8 +7,7 @@ import warnings
 from cgi import parse_header
 from collections import defaultdict, namedtuple
 from http.cookies import SimpleCookie
-from urllib.parse import parse_qs, parse_qsl, urlunparse
-
+from urllib.parse import parse_qs, parse_qsl, unquote, urlunparse
 
 from httptools import parse_url
 

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -4,7 +4,7 @@ import sys
 import warnings
 
 from cgi import parse_header
-from collections import namedtuple, defaultdict
+from collections import defaultdict, namedtuple
 from http.cookies import SimpleCookie
 from urllib.parse import parse_qs, parse_qsl, urlunparse
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -638,6 +638,9 @@ def test_request_not_grouped_args(app):
 
     assert request.not_grouped_args == params
 
+    # test cached value
+    assert request.parsed_not_grouped_args == request.not_grouped_args
+
     # test unique params
     params = [('test1', 'value1'), ('test2', 'value2')]
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -626,6 +626,31 @@ def test_request_raw_args(app):
     assert request.raw_args == params
 
 
+def test_request_not_grouped_args(app):
+    # test multiple params with the same key
+    params = [('test', 'value1'), ('test', 'value2')]
+
+    @app.get("/")
+    def handler(request):
+        return text("pass")
+
+    request, response = app.test_client.get("/", params=params)
+
+    assert request.not_grouped_args == params
+
+    # test unique params
+    params = [('test1', 'value1'), ('test2', 'value2')]
+
+    request, response = app.test_client.get("/", params=params)
+
+    assert request.not_grouped_args == params
+
+    # test no params
+    request, response = app.test_client.get("/")
+
+    assert not request.not_grouped_args
+
+
 def test_request_cookies(app):
 
     cookies = {"test": "OK"}


### PR DESCRIPTION
`Request.raw_args` has a huge bug - it takes only the first value of the parameter.
In case of the URLs with `?key1=value1&key2=value2&key1=value3` querystring, `key1` will get `["value1", "value3"]` in `Request.args` and only `value1` in `Request.raw_args`. 

And you can't call it even raw - it is parsed and then reduced.

As it is no opportunity to return multiple equal keys using `dict` for the backward compatibility I created another property `Request.not_grouped_args` that returns list of tuples from `urllib.parse.parse_qsl` method.
I think it is better avoid using `raw_args` and cut it from the future versions.