### PR TITLE
Upgrade setuptools version and use native docutils in doc build

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,21 +1,18 @@
-name: py35
+name: py36
 dependencies:
-- openssl=1.0.2g=0
-- pip=8.1.1=py35_0
-- python=3.5.1=0
-- readline=6.2=2
-- setuptools=40.4.3=py35_0
-- sqlite=3.9.2=0
-- tk=8.5.18=0
-- wheel=0.29.0=py35_0
-- xz=5.0.5=1
-- zlib=1.2.8=0
+- pip=18.1=py36_0
+- python=3.6.5=0
+- setuptools=40.4.3=py36_0
 - pip:
-  - uvloop>=0.5.3
   - httptools>=0.0.10
+  - uvloop>=0.5.3
   - ujson>=1.35
   - aiofiles>=0.3.0
-  - websockets>=6.0
-  - sphinxcontrib-asyncio>=0.2.0
+  - websockets>=6.0,<7.0
   - multidict>=4.0,<5.0
+  - sphinx==1.8.3
+  - sphinx_rtd_theme==0.4.2
+  - recommonmark==0.5.0
+  - sphinxcontrib-asyncio>=0.2.0
   - docutils==0.14
+  - pygments==2.3.1

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ dependencies:
 - pip=8.1.1=py35_0
 - python=3.5.1=0
 - readline=6.2=2
-- setuptools=20.3=py35_0
+- setuptools=40.4.3=py35_0
 - sqlite=3.9.2=0
 - tk=8.5.18=0
 - wheel=0.29.0=py35_0
@@ -18,4 +18,4 @@ dependencies:
   - websockets>=6.0
   - sphinxcontrib-asyncio>=0.2.0
   - multidict>=4.0,<5.0
-  - https://github.com/channelcat/docutils-fork/zipball/master
+  - docutils==0.14


### PR DESCRIPTION
The doc builds are always failed about one week ago. The reason is `recommonmark` has released a new version a week ago and install this new version with `setuptools==20.3`(`Sanic` use this version as doc build environment, check [this](https://github.com/huge-success/sanic/blob/2758a3ade6d05a5456c3b8522f092a8226d9c52e/environment.yml#L7)) cause an error. Use a newer version of `setuptools` can fix this issue. I also use native `docutils` in the doc build environment and it works properly(see #1354).