### PR TITLE
Add stream support for bp.add_route()

### DIFF
--- a/docs/sanic/streaming.md
+++ b/docs/sanic/streaming.md
@@ -42,7 +42,7 @@ async def handler(request):
 
 
 @bp.put('/bp_stream', stream=True)
-async def bp_handler(request):
+async def bp_put_handler(request):
     result = ''
     while True:
         body = await request.stream.read()
@@ -50,6 +50,19 @@ async def bp_handler(request):
             break
         result += body.decode('utf-8').replace('1', 'A')
     return text(result)
+
+
+# You can also use `bp.add_route()` with stream argument
+async def bp_post_handler(request):
+    result = ''
+    while True:
+        body = await request.stream.read()
+        if body is None:
+            break
+        result += body.decode('utf-8').replace('1', 'A')
+    return text(result)
+
+bp.add_route(bp_post_handler, '/bp_stream', methods=['POST'], stream=True)
 
 
 async def post_handler(request):

--- a/sanic/blueprints.py
+++ b/sanic/blueprints.py
@@ -212,6 +212,7 @@ class Blueprint:
         strict_slashes=None,
         version=None,
         name=None,
+        stream=False,
     ):
         """Create a blueprint route from a function.
 
@@ -224,6 +225,7 @@ class Blueprint:
             training */*
         :param version: Blueprint Version
         :param name: user defined route name for url_for
+        :param stream: boolean specifying if the handler is a stream handler
         :return: function or class instance
         """
         # Handle HTTPMethodView differently
@@ -246,6 +248,7 @@ class Blueprint:
             methods=methods,
             host=host,
             strict_slashes=strict_slashes,
+            stream=stream,
             version=version,
             name=name,
         )(handler)

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -117,7 +117,7 @@ class StreamingHTTPResponse(BaseHTTPResponse):
 
         headers = self._parse_headers()
 
-        if self.status is 200:
+        if self.status == 200:
             status = b"OK"
         else:
             status = STATUS_CODES.get(self.status)
@@ -176,7 +176,7 @@ class HTTPResponse(BaseHTTPResponse):
 
         headers = self._parse_headers()
 
-        if self.status is 200:
+        if self.status == 200:
             status = b"OK"
         else:
             status = STATUS_CODES.get(self.status, b"UNKNOWN RESPONSE")


### PR DESCRIPTION
This PR adds `stream` argument for `bp.add_route()` to provide another solution if someone wants to using blueprint with request stream.