### PR TITLE
sanic-zipkin

### DIFF
--- a/docs/sanic/extensions.md
+++ b/docs/sanic/extensions.md
@@ -67,6 +67,7 @@ A list of Sanic extensions created by the community.
 ## Monitoring and Reporting
 
 - [sanic-prometheus](https://github.com/dkruchinin/sanic-prometheus): Prometheus metrics for Sanic
+- [sanic-zipkin](https://github.com/kevinqqnj/sanic-zipkin): Easily report request/function/RPC traces to zipkin/jaeger, through aiozipkin.
 
 
 ## Sample Applications


### PR DESCRIPTION
add zipkin plugin.

Features:
- adding "Request span" by default
- if Request is from another micro-service endpoint, span will be attached (Inject/Extract) to that endpoint
- use "logger" decorator to create span for "methods" calls
- use "sz_rpc" method to create sub-span for RPC calls, attaching to parent span