### PR TITLE
WIP - Replace ujson with orjson as default json library

### DIFF
--- a/sanic/request.py
+++ b/sanic/request.py
@@ -15,7 +15,10 @@ from sanic.log import error_logger, logger
 
 
 try:
-    from ujson import loads as json_loads
+    if sys.version_info < (3, 6):
+        from orjson import loads as json_loads
+    else:
+        from ujson import loads as json_loads
 except ImportError:
     if sys.version_info[:2] == (3, 5):
 

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -205,6 +205,14 @@ class HTTPResponse(BaseHTTPResponse):
 
 
 def json_dumps(*args, **kwargs):
+    """
+    This method provides a non breaking change for the python
+    imports being done by the existing code if any.
+
+    If any of the current code was doing a
+    `from sanic.response import json_dumps`, the behavior can
+    change since orjson.dumps returns bytes by default as return
+    """
     data = _json_dumps(*args, **kwargs)
     if isinstance(data, bytes):
         data = data.decode("utf-8")

--- a/sanic/testing.py
+++ b/sanic/testing.py
@@ -1,9 +1,9 @@
 from json import JSONDecodeError
+from socket import socket
 
 from sanic.exceptions import MethodNotSupported
 from sanic.log import logger
 from sanic.response import text
-from socket import socket
 
 
 HOST = "127.0.0.1"

--- a/setup.py
+++ b/setup.py
@@ -73,17 +73,22 @@ setup_kwargs = {
 env_dependency = (
     '; sys_platform != "win32" ' 'and implementation_name == "cpython"'
 )
-ujson = "ujson>=1.35" + env_dependency
+
+ujson = "ujson>=1.35" + env_dependency + ' and python_version < "3.6"'
+orjson = 'orjson>=2.0.1; implementation_name == "cpython" and python_version > "3.5"'
 uvloop = "uvloop>=0.5.3" + env_dependency
 
 requirements = [
     "httptools>=0.0.10",
     uvloop,
     ujson,
+    orjson,
     "aiofiles>=0.3.0",
     "websockets>=6.0,<7.0",
     "multidict>=4.0,<5.0",
 ]
+
+print(requirements)
 
 tests_require = [
     "pytest==4.1.0",
@@ -94,9 +99,15 @@ tests_require = [
     "beautifulsoup4",
     uvloop,
     ujson,
+    orjson,
     "pytest-sanic",
     "pytest-sugar",
 ]
+
+if strtobool(os.environ.get("SANIC_NO_ORJSON", "no")):
+    print("Installing without orjson")
+    requirements.remove(orjson)
+    tests_require.remove(orjson)
 
 if strtobool(os.environ.get("SANIC_NO_UJSON", "no")):
     print("Installing without uJSON")

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = py35, py36, py37, {py35,py36,py37}-no-ext, lint, check
 [testenv]
 usedevelop = True
 setenv =
+    {py35,py36,py37}-no-ext: SANIC_NO_ORJSON=1
     {py35,py36,py37}-no-ext: SANIC_NO_UJSON=1
     {py35,py36,py37}-no-ext: SANIC_NO_UVLOOP=1
 deps =


### PR DESCRIPTION
Address the default JSON library replacement item mentioned in #1479 

Since https://github.com/ijl/orjson has started supporting wheel for all platforms, I suppose we can not migrate to orjson as the default library for python3.6 and above. However, for 3.5, we will still retain `ujson` until `orjson` is backported to it or we decide to drop `ujson` completely and rely on default json for python3.5