### PR TITLE
Bump version to 19.03.0

### DIFF
--- a/sanic/__init__.py
+++ b/sanic/__init__.py
@@ -2,6 +2,6 @@ from sanic.app import Sanic
 from sanic.blueprints import Blueprint
 
 
-__version__ = "18.12.0"
+__version__ = "19.03.0"
 
 __all__ = ["Sanic", "Blueprint"]


### PR DESCRIPTION
The old `19.3` tag should get removed and remade when this gets merged in and then the upload to `PyPI` should get resolved.

I'll handle the re-tagging, if/when this gets merged.

Closes #1524 

cc @ahopkins 