### PR TITLE
Add options to control the behavior of Request.remote_addr

### DIFF
--- a/docs/sanic/config.md
+++ b/docs/sanic/config.md
@@ -85,16 +85,19 @@ DB_USER = 'appuser'
 
 Out of the box there are just a few predefined values which can be overwritten when creating the application.
 
-    | Variable                  | Default   | Description                                               |
-    | ------------------------- | --------- | --------------------------------------------------------- |
-    | REQUEST_MAX_SIZE          | 100000000 | How big a request may be (bytes)                          |
-    | REQUEST_BUFFER_QUEUE_SIZE | 100       | Request streaming buffer queue size                    |
-    | REQUEST_TIMEOUT           | 60        | How long a request can take to arrive (sec)               |
-    | RESPONSE_TIMEOUT          | 60        | How long a response can take to process (sec)             |
-    | KEEP_ALIVE                | True      | Disables keep-alive when False                            |
-    | KEEP_ALIVE_TIMEOUT        | 5         | How long to hold a TCP connection open (sec)              |
-    | GRACEFUL_SHUTDOWN_TIMEOUT | 15.0      | How long to wait to force close non-idle connection (sec) |
-    | ACCESS_LOG                | True      | Disable or enable access log                              |
+    | Variable                  | Default           | Description                                                                 |
+    | ------------------------- | ----------------- | --------------------------------------------------------------------------- |
+    | REQUEST_MAX_SIZE          | 100000000         | How big a request may be (bytes)                                            |
+    | REQUEST_BUFFER_QUEUE_SIZE | 100               | Request streaming buffer queue size                                         |
+    | REQUEST_TIMEOUT           | 60                | How long a request can take to arrive (sec)                                 |
+    | RESPONSE_TIMEOUT          | 60                | How long a response can take to process (sec)                               |
+    | KEEP_ALIVE                | True              | Disables keep-alive when False                                              |
+    | KEEP_ALIVE_TIMEOUT        | 5                 | How long to hold a TCP connection open (sec)                                |
+    | GRACEFUL_SHUTDOWN_TIMEOUT | 15.0              | How long to wait to force close non-idle connection (sec)                   |
+    | ACCESS_LOG                | True              | Disable or enable access log                                                |
+    | PROXIES_COUNT             | -1                | The number of proxy servers in front of the app (e.g. nginx; see below)     |
+    | FORWARDED_FOR_HEADER      | "X-Forwarded-For" | The name of "X-Forwarded-For" HTTP header that contains client and proxy ip |
+    | REAL_IP_HEADER            | "X-Real-IP"       | The name of "X-Real-IP" HTTP header that contains real client ip            |
 
 ### The different Timeout variables:
 
@@ -143,3 +146,17 @@ Firefox client hard keepalive limit = 115 seconds
 Opera 11 client hard keepalive limit = 120 seconds
 Chrome 13+ client keepalive limit > 300+ seconds
 ```
+
+### About proxy servers and client ip
+
+When you use a reverse proxy server (e.g. nginx), the value of `request.ip` will contain ip of a proxy, typically `127.0.0.1`. To determine the real client ip, `X-Forwarded-For` and `X-Real-IP` HTTP headers are used. But client can fake these headers if they have not been overridden by a proxy. Sanic has a set of options to determine the level of confidence in these headers.
+
+* If you have a single proxy, set `PROXIES_COUNT` to `1`. Then Sanic will use `X-Real-IP` if available or the last ip from `X-Forwarded-For`.
+
+* If you have multiple proxies, set `PROXIES_COUNT` equal to their number to allow Sanic to select the correct ip from `X-Forwarded-For`.
+
+* If you don't use a proxy, set `PROXIES_COUNT` to `0` to ignore these headers and prevent ip falsification.
+
+* If you don't use `X-Real-IP` (e.g. your proxy sends only `X-Forwarded-For`), set `REAL_IP_HEADER` to an empty string.
+
+The real ip will be available in `request.remote_addr`. If HTTP headers are unavailable or untrusted, `request.remote_addr` will be an empty string; in this case use `request.ip` instead.

--- a/docs/sanic/deploying.md
+++ b/docs/sanic/deploying.md
@@ -64,6 +64,26 @@ of the memory leak.
 
 See the [Gunicorn Docs](http://docs.gunicorn.org/en/latest/settings.html#max-requests) for more information.
 
+## Running behind a reverse proxy
+
+Sanic can be used with a reverse proxy (e.g. nginx). There's a simple example of nginx configuration:
+
+```
+server {
+  listen 80;
+  server_name example.org;
+
+  location / {
+    proxy_pass http://127.0.0.1:8000;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  }
+}
+```
+
+If you want to get real client ip, you should configure `X-Real-IP` and `X-Forwarded-For` HTTP headers and set `app.config.PROXIES_COUNT` to `1`; see the configuration page for more information.
+
 ## Disable debug logging
 
 To improve the performance add `debug=False` and `access_log=False` in the `run` arguments.

--- a/sanic/config.py
+++ b/sanic/config.py
@@ -27,6 +27,9 @@ DEFAULT_CONFIG = {
     "WEBSOCKET_WRITE_LIMIT": 2 ** 16,
     "GRACEFUL_SHUTDOWN_TIMEOUT": 15.0,  # 15 sec
     "ACCESS_LOG": True,
+    "PROXIES_COUNT": -1,
+    "FORWARDED_FOR_HEADER": "X-Forwarded-For",
+    "REAL_IP_HEADER": "X-Real-IP",
 }
 
 


### PR DESCRIPTION
Closes #801 

Using `X-Forwarded-For` to determine real client ip is totally unsafe when proxy is not used, because client can fake this http header. This PR adds `PROXIES_COUNT` option to control the usage of this http header.

When nginx is used, `PROXIES_COUNT` should be `1` and `X-Forwarded-For` will be parsed. When nginx is not used (or does not override `X-Forwarded-For`), `PROXIES_COUNT` should be `0` and `X-Forwarded-For` will be ignored.

This PR also adds `X-Real-IP` that is very useful with nginx, and `FORWARDED_FOR_HEADER` and `REAL_IP_HEADER` options that allow to change the names of these headers.

There are some weird things:

* `PROXIES_COUNT` is `-1` by default, which means using the first ip from `X-Forwarded-For`. It's still totally unsafe, but backwards-compatible. It should be set to `0` for security reasons, but it changes the default behavior and probably breaks the compatibility.

* When `X-Forwarded-For` or `X-Real-IP` are unavailable or untrusted, `request.remote_addr` returns an empty string. This is compatible with the old behavior, but this is weird, I don't know why I have to use `ip = (request.remote_addr or request.ip)` boilerplate.

* English is not my native language, and I use Google Translate, so the documentation may be crappy, sorry for that D: