### PR TITLE
stop number route accepting excess '.'s

### DIFF
--- a/sanic/router.py
+++ b/sanic/router.py
@@ -18,7 +18,7 @@ Parameter = namedtuple("Parameter", ["name", "cast"])
 REGEX_TYPES = {
     "string": (str, r"[^/]+"),
     "int": (int, r"-?\d+"),
-    "number": (float, r"-?[0-9\\.]+"),
+    "number": (float, r"-?(?:\d+(?:\.\d*)?|\.\d+)"),
     "alpha": (str, r"[A-Za-z]+"),
     "path": (str, r"[^/].*?"),
     "uuid": (

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -365,7 +365,16 @@ def test_dynamic_route_number(app):
     request, response = app.test_client.get("/weight/1234.56")
     assert response.status == 200
 
+    request, response = app.test_client.get("/weight/.12")
+    assert response.status == 200
+
+    request, response = app.test_client.get("/weight/12.")
+    assert response.status == 200
+
     request, response = app.test_client.get("/weight/1234-56")
+    assert response.status == 404
+
+    request, response = app.test_client.get("/weight/12.34.56")
     assert response.status == 404
 
 
@@ -672,7 +681,16 @@ def test_dynamic_add_route_number(app):
     request, response = app.test_client.get("/weight/1234.56")
     assert response.status == 200
 
+    request, response = app.test_client.get("/weight/.12")
+    assert response.status == 200
+
+    request, response = app.test_client.get("/weight/12.")
+    assert response.status == 200
+
     request, response = app.test_client.get("/weight/1234-56")
+    assert response.status == 404
+
+    request, response = app.test_client.get("/weight/12.34.56")
     assert response.status == 404
 
 

--- a/tests/test_url_building.py
+++ b/tests/test_url_building.py
@@ -223,7 +223,7 @@ def test_fails_with_number_message(app):
 
     expected_error = (
         'Value "foo" for parameter `some_number` '
-        "does not match pattern for type `float`: -?[0-9\\\\.]+"
+        r"does not match pattern for type `float`: -?(?:\d+(?:\.\d*)?|\.\d+)"
     )
 
     assert str(e.value) == expected_error


### PR DESCRIPTION
This stops this error

    ValueError: could not convert string to float: '12.34.56'

when passing 12.34.56 as a number route parameter argument.
By accepting ".12" and "12.", this is a non-breaking change. All valid
floats described by [0-9\.]+ are still accepted, just invalid ones are
now rejected.