### PR TITLE
Drop dependency on disutils

### DIFF
--- a/sanic/config.py
+++ b/sanic/config.py
@@ -1,8 +1,6 @@
 import os
 import types
 
-from distutils.util import strtobool
-
 from sanic.exceptions import PyFileError
 
 
@@ -130,3 +128,16 @@ class Config(dict):
                             self[config_key] = bool(strtobool(v))
                         except ValueError:
                             self[config_key] = v
+
+def strtobool (val):
+    """
+    This function was borrowed from distutils.utils. While distutils
+    is part of stdlib, it feels odd to use distutils in main application code.
+    """
+    val = val.lower()
+    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+        return 1
+    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+        return 0
+    else:
+        raise ValueError("invalid truth value %r" % (val,))

--- a/sanic/config.py
+++ b/sanic/config.py
@@ -125,7 +125,7 @@ class Config(dict):
                         self[config_key] = float(v)
                     except ValueError:
                         try:
-                            self[config_key] = bool(strtobool(v))
+                            self[config_key] = strtobool(v)
                         except ValueError:
                             self[config_key] = v
 
@@ -134,11 +134,14 @@ def strtobool(val):
     """
     This function was borrowed from distutils.utils. While distutils
     is part of stdlib, it feels odd to use distutils in main application code.
+
+    The function was modified to walk its talk and actually return bool
+    and not int.
     """
     val = val.lower()
     if val in ("y", "yes", "t", "true", "on", "1"):
-        return 1
+        return True
     elif val in ("n", "no", "f", "false", "off", "0"):
-        return 0
+        return False
     else:
         raise ValueError("invalid truth value %r" % (val,))

--- a/sanic/config.py
+++ b/sanic/config.py
@@ -129,7 +129,8 @@ class Config(dict):
                         except ValueError:
                             self[config_key] = v
 
-def strtobool (val):
+
+def strtobool(val):
     """
     This function was borrowed from distutils.utils. While distutils
     is part of stdlib, it feels odd to use distutils in main application code.

--- a/sanic/config.py
+++ b/sanic/config.py
@@ -136,9 +136,9 @@ def strtobool(val):
     is part of stdlib, it feels odd to use distutils in main application code.
     """
     val = val.lower()
-    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+    if val in ("y", "yes", "t", "true", "on", "1"):
         return 1
-    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+    elif val in ("n", "no", "f", "false", "off", "0"):
         return 0
     else:
         raise ValueError("invalid truth value %r" % (val,))


### PR DESCRIPTION
Good day,

Recently sanic's main code started to use distutils solely for `disturils.util.strtobool` function.

I use [minimal](https://hub.docker.com/r/haizaar/python-minimal) python docker image (30MB) that does not include distutils. Distutils weighs 3MB which is 10% increase for the image size.
Hence I propose to implement `strtobool` function as part of `sanic/config.py`.

While distutils is part of stdlib and is expected to be present, it has a certain purpose and seeing `from distutils` import in main application code may look odd to some.