### PR TITLE
Fix #1551 add missing parameter in create_server

### DIFF
--- a/docs/sanic/deploying.md
+++ b/docs/sanic/deploying.md
@@ -92,7 +92,7 @@ to run the app in general.
 Here is an incomplete example (please see `run_async.py` in examples for something more practical):
 
 ```python
-server = app.create_server(host="0.0.0.0", port=8000)
+server = app.create_server(host="0.0.0.0", port=8000, return_asyncio_server=True)
 loop = asyncio.get_event_loop()
 task = asyncio.ensure_future(server)
 loop.run_forever()

--- a/examples/log_request_id.py
+++ b/examples/log_request_id.py
@@ -76,7 +76,7 @@ async def test(request):
 
 if __name__ == '__main__':
     asyncio.set_event_loop(uvloop.new_event_loop())
-    server = app.create_server(host="0.0.0.0", port=8000)
+    server = app.create_server(host="0.0.0.0", port=8000, return_asyncio_server=True)
     loop = asyncio.get_event_loop()
     loop.set_task_factory(context.task_factory)
     task = asyncio.ensure_future(server)

--- a/examples/run_async.py
+++ b/examples/run_async.py
@@ -12,7 +12,7 @@ async def test(request):
     return response.json({"answer": "42"})
 
 asyncio.set_event_loop(uvloop.new_event_loop())
-server = app.create_server(host="0.0.0.0", port=8000)
+server = app.create_server(host="0.0.0.0", port=8000, return_asyncio_server=True)
 loop = asyncio.get_event_loop()
 task = asyncio.ensure_future(server)
 signal(SIGINT, lambda s, f: loop.stop())


### PR DESCRIPTION
The new `return_asyncio_server` parameter of `create_server` function was missing in examples and documentation.