### PR TITLE
doc: fix README.rst for pip installing sanic without uvloop and ujson

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ Installation
     
        $ export SANIC_NO_UVLOOP=true
        $ export SANIC_NO_UJSON=true 
-       $ pip3 install sanic
+       $ pip3 install --no-binary :all: sanic
 
 
 Hello World Example


### PR DESCRIPTION
pip enables wheel install by default, which is bdist (built dist). it doesn't run setup.py. Currently, It's still installing uvloop and ujson even if `export SANIC_NO_UVLOOP=true` and `export SANIC_NO_UJSON=true`