### PR TITLE
Fix graceful shutdown

### DIFF
--- a/sanic/server.py
+++ b/sanic/server.py
@@ -119,7 +119,7 @@ class HttpProtocol(asyncio.Protocol):
         self.router = router
         self.signal = signal
         self.access_log = access_log
-        self.connections = connections or set()
+        self.connections = connections if connections is not None else set()
         self.request_handler = request_handler
         self.error_handler = error_handler
         self.request_timeout = request_timeout

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -554,11 +554,15 @@ class HttpProtocol(asyncio.Protocol):
 
         :return: None
         """
-        if from_error or self.transport.is_closing():
+        if from_error or self.transport is None or self.transport.is_closing():
             logger.error(
                 "Transport closed @ %s and exception "
                 "experienced during error handling",
-                self.transport.get_extra_info("peername"),
+                (
+                    self.transport.get_extra_info("peername")
+                    if self.transport is not None
+                    else "N/A"
+                ),
             )
             logger.debug("Exception:", exc_info=True)
         else:


### PR DESCRIPTION
This line broke the graceful shutdown: https://github.com/huge-success/sanic/pull/1423/files#diff-bd84a6e523017a7f3d6bd72ee689dce2R110

Because a `empty_set or set()` expression will always create a new set insead of reusing an existing empty set

*(The closed `HttpProtocol` is totally broken and unstable because `self.transport` is `None` >_<)*