### PR TITLE
Fix typo in request_data.md, docs.

### DIFF
--- a/docs/sanic/request_data.md
+++ b/docs/sanic/request_data.md
@@ -193,7 +193,7 @@ The output will be:
 {
     "parsed": true,
     "url": "http:\/\/0.0.0.0:8000\/query_string?test1=value1&test2=&test3=value3",
-    "args_with_blank_values": {"test1": ["value1""], "test2": "", "test3": ["value3"]},
+    "args_with_blank_values": {"test1": ["value1"], "test2": "", "test3": ["value3"]},
     "query_string": "test1=value1&test2=&test3=value3"
 }
 ```


### PR DESCRIPTION
This seems strange in [docs](https://sanic.readthedocs.io/en/latest/sanic/request_data.html#changing-the-default-parsing-rules-of-the-queryset).