### PR TITLE
Resolve deprecation notice for import of an ABC from collections module

### DIFF
--- a/sanic/blueprint_group.py
+++ b/sanic/blueprint_group.py
@@ -1,4 +1,4 @@
-from collections import MutableSequence
+from collections.abc import MutableSequence
 
 
 class BlueprintGroup(MutableSequence):


### PR DESCRIPTION
Resolving deprecation warning.

```
/home/adam/.virtualenvs/sanictesting/lib/python3.7/site-packages/sanic/blueprint_group.py:1
  /home/adam/.virtualenvs/sanictesting/lib/python3.7/site-packages/sanic/blueprint_group.py:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import MutableSequence

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```