### PR TITLE
Updated routing docs

### DIFF
--- a/docs/sanic/routing.md
+++ b/docs/sanic/routing.md
@@ -59,8 +59,7 @@ on the URL.
     * 123a123a-a12a-1a1a-a1a1-1a12a1a12345 and all other UUIDv4 work here
 * regex expression
 
-If no type is set then a string is expected. The argument given to the function will
-    always be a string, independent of the type.
+If no type is set then a string is expected. The argument given to the function will always be a string, independent of the type.
 
 ```python
 from sanic.response import text
@@ -98,6 +97,8 @@ async def folder_handler(request, folder_id):
     return text('Folder - {}'.format(folder_id))
 
 ```
+
+**Warning** `str` is not a valid type tag. If you want `str` recognition then you must use `string` 
 
 ## HTTP request types
 

--- a/docs/sanic/routing.md
+++ b/docs/sanic/routing.md
@@ -41,24 +41,61 @@ inside the quotes. If the parameter does not match the specified type, Sanic
 will throw a `NotFound` exception, resulting in a `404: Page not found` error
 on the URL.
 
+### Supported types
+
+* string
+    * "Bob" or "Python 3" both would work here
+* int
+    * 10, 20, 30, -10 all work here
+    * No floats work here
+* number
+    * 1, 1.5, 10, -10 all work here
+* alpha
+    * "Bob", "Python" all work here
+    * If it contains a symbol or a non alphanumeric character it will fail
+* path
+    * "hello", "hello.text" and "hello world" all work here
+* uuid
+    * 123a123a-a12a-1a1a-a1a1-1a12a1a12345 and all other UUIDv4 work here
+* regex expression
+
+If no type is set then a string is expected. The argument given to the function will
+    always be a string, independent of the type.
+
 ```python
 from sanic.response import text
 
-@app.route('/number/<integer_arg:int>')
+@app.route('/string/<string_arg:string>')
+async def string_handler(request, string_arg):
+    return text('String - {}'.format(string_arg))
+
+@app.route('/int/<integer_arg:int>')
 async def integer_handler(request, integer_arg):
-	return text('Integer - {}'.format(integer_arg))
+    return text('Integer - {}'.format(integer_arg))
 
 @app.route('/number/<number_arg:number>')
 async def number_handler(request, number_arg):
-	return text('Number - {}'.format(number_arg))
+    return text('Number - {}'.format(number_arg))
+
+@app.route('/alpha/<alpha_arg:alpha>')
+async def number_handler(request, alpha_arg):
+    return text('Alpha - {}'.format(alpha_arg))
+    
+@app.route('/path/<path_arg:path>')
+async def number_handler(request, path_arg):
+    return text('Path - {}'.format(path_arg))
+
+@app.route('/uuid/<uuid_arg:uuid>')
+async def number_handler(request, uuid_arg):
+    return text('Uuid - {}'.format(uuid_arg))
 
 @app.route('/person/<name:[A-z]+>')
 async def person_handler(request, name):
-	return text('Person - {}'.format(name))
+    return text('Person - {}'.format(name))
 
 @app.route('/folder/<folder_id:[A-z0-9]{0,4}>')
 async def folder_handler(request, folder_id):
-	return text('Folder - {}'.format(folder_id))
+    return text('Folder - {}'.format(folder_id))
 
 ```
 

--- a/docs/sanic/routing.md
+++ b/docs/sanic/routing.md
@@ -43,21 +43,21 @@ on the URL.
 
 ### Supported types
 
-* string
+* `string`
     * "Bob" or "Python 3" both would work here
-* int
+* `int`
     * 10, 20, 30, -10 all work here
     * No floats work here
-* number
+* `number`
     * 1, 1.5, 10, -10 all work here
-* alpha
+* `alpha`
     * "Bob", "Python" all work here
     * If it contains a symbol or a non alphanumeric character it will fail
-* path
+* `path`
     * "hello", "hello.text" and "hello world" all work here
-* uuid
+* `uuid`
     * 123a123a-a12a-1a1a-a1a1-1a12a1a12345 and all other UUIDv4 work here
-* regex expression
+* `regex expression`
 
 If no type is set then a string is expected. The argument given to the function will always be a string, independent of the type.
 

--- a/docs/sanic/routing.md
+++ b/docs/sanic/routing.md
@@ -44,19 +44,29 @@ on the URL.
 ### Supported types
 
 * `string`
-    * "Bob" or "Python 3" both would work here
+    * "Bob"
+    * "Python 3"
 * `int`
-    * 10, 20, 30, -10 all work here
-    * No floats work here
+    * 10
+    * 20
+    * 30
+    * -10
+    * (No floats work here)
 * `number`
-    * 1, 1.5, 10, -10 all work here
+    * 1
+    * 1.5
+    * 10
+    * -10
 * `alpha`
-    * "Bob", "Python" all work here
-    * If it contains a symbol or a non alphanumeric character it will fail
+    * "Bob"
+    * "Python"
+    * (If it contains a symbol or a non alphanumeric character it will fail)
 * `path`
-    * "hello", "hello.text" and "hello world" all work here
+    * "hello"
+    * "hello.text"
+    * "hello world"
 * `uuid`
-    * 123a123a-a12a-1a1a-a1a1-1a12a1a12345 and all other UUIDv4 work here
+    * 123a123a-a12a-1a1a-a1a1-1a12a1a12345 (UUIDv4 Support)
 * `regex expression`
 
 If no type is set then a string is expected. The argument given to the function will always be a string, independent of the type.


### PR DESCRIPTION
Updated routing docs to show all supported types as defined within https://github.com/huge-success/sanic/blob/3685b4de85ff9c6803b789d245366684765e2551/sanic/router.py#L18
Added example code for all examples besides regex
Added examples of queries that work with that type and ones that would not

Created PR on recommendation from @ahopkins from this issue https://github.com/huge-success/sanic/issues/1606 