### PR TITLE
GIT1505: Backport changes from #1502 to 18.12LTS (#1507)

### DIFF
--- a/sanic/response.py
+++ b/sanic/response.py
@@ -117,7 +117,7 @@ class StreamingHTTPResponse(BaseHTTPResponse):
 
         headers = self._parse_headers()
 
-        if self.status is 200:
+        if self.status == 200:
             status = b"OK"
         else:
             status = STATUS_CODES.get(self.status)
@@ -176,7 +176,7 @@ class HTTPResponse(BaseHTTPResponse):
 
         headers = self._parse_headers()
 
-        if self.status is 200:
+        if self.status == 200:
             status = b"OK"
         else:
             status = STATUS_CODES.get(self.status, b"UNKNOWN RESPONSE")

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -34,9 +34,6 @@ except ImportError:
     pass
 
 
-current_time = None
-
-
 class Signal:
     stopped = False
 
@@ -157,7 +154,7 @@ class HttpProtocol(asyncio.Protocol):
             self.request_timeout, self.request_timeout_callback
         )
         self.transport = transport
-        self._last_request_time = current_time
+        self._last_request_time = time()
 
     def connection_lost(self, exc):
         self.connections.discard(self)
@@ -183,7 +180,7 @@ class HttpProtocol(asyncio.Protocol):
         # exactly what this timeout is checking for.
         # Check if elapsed time since request initiated exceeds our
         # configured maximum request timeout value
-        time_elapsed = current_time - self._last_request_time
+        time_elapsed = time() - self._last_request_time
         if time_elapsed < self.request_timeout:
             time_left = self.request_timeout - time_elapsed
             self._request_timeout_handler = self.loop.call_later(
@@ -199,7 +196,7 @@ class HttpProtocol(asyncio.Protocol):
     def response_timeout_callback(self):
         # Check if elapsed time since response was initiated exceeds our
         # configured maximum request timeout value
-        time_elapsed = current_time - self._last_request_time
+        time_elapsed = time() - self._last_request_time
         if time_elapsed < self.response_timeout:
             time_left = self.response_timeout - time_elapsed
             self._response_timeout_handler = self.loop.call_later(
@@ -215,7 +212,7 @@ class HttpProtocol(asyncio.Protocol):
     def keep_alive_timeout_callback(self):
         # Check if elapsed time since last response exceeds our configured
         # maximum keep alive timeout value
-        time_elapsed = current_time - self._last_response_time
+        time_elapsed = time() - self._last_response_time
         if time_elapsed < self.keep_alive_timeout:
             time_left = self.keep_alive_timeout - time_elapsed
             self._keep_alive_timeout_handler = self.loop.call_later(
@@ -327,7 +324,7 @@ class HttpProtocol(asyncio.Protocol):
         self._response_timeout_handler = self.loop.call_later(
             self.response_timeout, self.response_timeout_callback
         )
-        self._last_request_time = current_time
+        self._last_request_time = time()
         self._request_handler_task = self.loop.create_task(
             self.request_handler(
                 self.request, self.write_response, self.stream_response
@@ -403,7 +400,7 @@ class HttpProtocol(asyncio.Protocol):
                 self._keep_alive_timeout_handler = self.loop.call_later(
                     self.keep_alive_timeout, self.keep_alive_timeout_callback
                 )
-                self._last_response_time = current_time
+                self._last_response_time = time()
                 self.cleanup()
 
     async def drain(self):
@@ -456,7 +453,7 @@ class HttpProtocol(asyncio.Protocol):
                 self._keep_alive_timeout_handler = self.loop.call_later(
                     self.keep_alive_timeout, self.keep_alive_timeout_callback
                 )
-                self._last_response_time = current_time
+                self._last_response_time = time()
                 self.cleanup()
 
     def write_error(self, exception):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -138,6 +138,7 @@ def test_handle_request_with_nested_sanic_exception(app, monkeypatch, caplog):
         raise Exception
         return text('OK')
 
+    caplog.set_level(logging.ERROR, logger="sanic.root")
     with caplog.at_level(logging.ERROR):
         request, response = app.test_client.get('/')
     assert response.status == 500

--- a/tests/test_keep_alive_timeout.py
+++ b/tests/test_keep_alive_timeout.py
@@ -141,7 +141,7 @@ class ReuseableSanicTestClient(SanicTestClient):
                 conn = self._tcp_connector
             else:
                 conn = ReuseableTCPConnector(
-                    verify_ssl=False,
+                    ssl=False,
                     loop=self._loop,
                     keepalive_timeout=request_keepalive
                 )

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -81,6 +81,7 @@ def test_middleware_response_raise_cancelled_error(app, caplog):
     def handler(request):
         return text('OK')
 
+    caplog.set_level(logging.ERROR, logger="sanic.root")
     with caplog.at_level(logging.ERROR):
         reqrequest, response = app.test_client.get('/')
 
@@ -98,6 +99,7 @@ def test_middleware_response_raise_exception(app, caplog):
     async def process_response(request, response):
         raise Exception('Exception at response middleware')
 
+    caplog.set_level(logging.ERROR, logger="sanic.root")
     with caplog.at_level(logging.ERROR):
         reqrequest, response = app.test_client.get('/')
 

--- a/tests/test_request_timeout.py
+++ b/tests/test_request_timeout.py
@@ -149,7 +149,7 @@ class DelayableSanicTestClient(SanicTestClient):
             url = 'http://{host}:{port}{uri}'.format(
                 host=HOST, port=self.port, uri=uri)
         conn = DelayableTCPConnector(pre_request_delay=self._request_delay,
-                                     verify_ssl=False, loop=self._loop)
+                                     ssl=False, loop=self._loop)
         async with aiohttp.ClientSession(cookies=cookies, connector=conn,
                                          loop=self._loop) as session:
             # Insert a delay after creating the connection

--- a/tests/test_url_building.py
+++ b/tests/test_url_building.py
@@ -155,8 +155,8 @@ def test_fails_with_int_message(app):
         app.url_for('fail', **failing_kwargs)
 
     expected_error = (
-        'Value "not_int" for parameter `foo` '
-        'does not match pattern for type `int`: \d+')
+        r'Value "not_int" for parameter `foo` '
+        r'does not match pattern for type `int`: \d+')
     assert str(e.value) == expected_error
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ setenv =
     {py35,py36,py37}-no-ext: SANIC_NO_UVLOOP=1
 deps =
     coverage
-    pytest==3.3.2
+    pytest>=3.6
     pytest-cov
     pytest-sanic
     pytest-sugar


### PR DESCRIPTION
* GIT1505: backport changes from #1502 to 18.12LTS

* GIT1505: fix pytest version to address UT failures

* fix: GIT1505: fix unittests with caplog and some other warnings

Signed-off-by: Harsha Narayana <harsha2k4@gmail.com>