### PR TITLE
Abort documentation

### DIFF
--- a/docs/sanic/exceptions.md
+++ b/docs/sanic/exceptions.md
@@ -25,9 +25,7 @@ from sanic.response import text
 
 @app.route('/youshallnotpass')
 async def no_no(request):
-        abort(401)
-        # this won't happen
-        text("OK")
+        return abort(401)
 ```
 
 ## Handling exceptions
@@ -60,7 +58,7 @@ app.error_handler.add(Exception, server_error_handler)
 ```
 
 In some cases, you might want to add some more error handling
-functionality to what is provided by default. In that case, you 
+functionality to what is provided by default. In that case, you
 can subclass Sanic's default error handler as such:
 
 ```python
@@ -72,7 +70,7 @@ class CustomErrorHandler(ErrorHandler):
 		''' handles errors that have no error handlers assigned '''
 		# You custom error handling logic...
 		return super().default(request, exception)
-		
+
 app = Sanic()
 app.error_handler = CustomErrorHandler()
 ```

--- a/docs/sanic/exceptions.md
+++ b/docs/sanic/exceptions.md
@@ -25,7 +25,8 @@ from sanic.response import text
 
 @app.route('/youshallnotpass')
 async def no_no(request):
-        return abort(401)
+
+	return abort(401)
 ```
 
 ## Handling exceptions

--- a/docs/sanic/exceptions.md
+++ b/docs/sanic/exceptions.md
@@ -25,7 +25,6 @@ from sanic.response import text
 
 @app.route('/youshallnotpass')
 async def no_no(request):
-
 	return abort(401)
 ```
 

--- a/sanic/exceptions.py
+++ b/sanic/exceptions.py
@@ -294,6 +294,8 @@ def abort(status_code, message=None):
     :param status_code: The HTTP status code to return.
     :param message: The HTTP response body. Defaults to the messages
                     in response.py for the given status code.
+
+    :return: HTTP response message for status code.
     """
     if message is None:
         message = STATUS_CODES.get(status_code)


### PR DESCRIPTION
During development, saw that the abort example was missing the return statement, so I made a change to that. Also in the API docs, I made a quick update to make more clear that abort does have a return object.