### PR TITLE
check for already set asyncio event loop policy

### DIFF
--- a/sanic/server.py
+++ b/sanic/server.py
@@ -29,8 +29,9 @@ from sanic.response import HTTPResponse
 
 try:
     import uvloop
-
-    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+    
+    if not isinstance(asyncio.get_event_loop_policy(), uvloop.EventLoopPolicy):
+        asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 except ImportError:
     pass
 


### PR DESCRIPTION
For projects using app.create_server instead of app.run, if event loop policy is already set to uvloops policy externally, sanic will reset it and may cause two asyncio event loops to spawn, one from the earlier policy and one with the policy set by sanic.

This patch will check if asyncio event loop policy is already set as uvloop policy and won't reset it, if so.