### PR TITLE
Fix server crash on request.server_port when bound to IPv6.

### DIFF
--- a/sanic/request.py
+++ b/sanic/request.py
@@ -388,7 +388,7 @@ class Request(dict):
         if forwarded_port:
             return int(forwarded_port)
         else:
-            _, port = self.transport.get_extra_info("sockname")
+            port = self.transport.get_extra_info("sockname")[1]
             return port
 
     @property


### PR DESCRIPTION
If no X-Forwarded-Port nor Host headers are present, Sanic uses "sockname"
to determine the port. This expected (host, port) tuple to be returned but
for IPv6 a 4-tuple is returned instead. Changed code so that port is picked
up in either case. Handling of "peername" was already correct in this regard.

_get_address and server_port both still return incorrect data or crash for
other socket types (e.g unix). Socket type should checked before any queries.