### PR TITLE
Fix the link to CHANGELOG in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -131,7 +131,7 @@ Documentation
 Changelog
 ---------
 
-`Release Changelogs <https://github.com/huge-success/sanic/blob/master/CHANGELOG.md>`_.
+`Release Changelogs <https://github.com/huge-success/sanic/blob/master/CHANGELOG.rst>`_.
 
    
 Questions and Discussion


### PR DESCRIPTION
Fix the incorrect link to `CHANGELOG` in [README.rst](https://github.com/huge-success/sanic/blob/master/README.rst) from `CHANGELOG.md` to `CHANGELOG.rst`.

Reference: #1664 
