### PR TITLE
Update Docs for Static files

### DIFF
--- a/docs/sanic/static_files.md
+++ b/docs/sanic/static_files.md
@@ -34,6 +34,10 @@ app.url_for('static', name='another', filename='any') == '/another.png'
 bp = Blueprint('bp', url_prefix='/bp')
 bp.static('/static', './static')
 
+# specify a different content_type for your files
+# such as adding 'charset'
+app.static('/', '/public/index.html', content_type="text/html; charset=utf-8")
+
 # servers the file directly
 bp.static('/the_best.png', '/home/ubuntu/test.png', name='best_png')
 app.blueprint(bp)


### PR DESCRIPTION
Update Docs for Static files to include a mention that you can adjust the content_type of a static resource as it wasn't previously mentioned in the Docs and I had to find out you could do this via Googleing and finding a previous PR which implemented it https://github.com/huge-success/sanic/pull/1267