### PR TITLE
Fixes "after_server_start" when using return_asyncio_server.

### DIFF
--- a/docs/sanic/deploying.md
+++ b/docs/sanic/deploying.md
@@ -158,3 +158,34 @@ loop = asyncio.get_event_loop()
 task = asyncio.ensure_future(server)
 loop.run_forever()
 ```
+
+Caveat: using this method, calling `app.create_server()` will trigger "before_server_start" server events, but not
+"after_server_start", "before_server_stop", or "after_server_stop" server events.
+
+For more advanced use-cases, you can trigger these events using the AsyncServerCoro object, returned by awaiting
+the server task.
+
+Here is an incomplete example (please see `run_async_advanced.py` in examples for something more complete):
+
+```python
+serv_coro = app.create_server(host="0.0.0.0", port=8000, return_asyncio_server=True)
+loop = asyncio.get_event_loop()
+serv_task = asyncio.ensure_future(serv_coro, loop=loop)
+server = loop.run_until_complete(serv_task)
+server.after_start()
+try:
+    loop.run_forever()
+except KeyboardInterrupt as e:
+    loop.stop()
+finally:
+    server.before_stop()
+
+    # Wait for server to close
+    close_task = server.close()
+    loop.run_until_complete(close_task)
+
+    # Complete all tasks on the loop
+    for connection in server.connections:
+        connection.close_if_idle()
+    server.after_stop()
+```

--- a/docs/sanic/deploying.md
+++ b/docs/sanic/deploying.md
@@ -162,7 +162,7 @@ loop.run_forever()
 Caveat: using this method, calling `app.create_server()` will trigger "before_server_start" server events, but not
 "after_server_start", "before_server_stop", or "after_server_stop" server events.
 
-For more advanced use-cases, you can trigger these events using the AsyncServerCoro object, returned by awaiting
+For more advanced use-cases, you can trigger these events using the AsyncioServer object, returned by awaiting
 the server task.
 
 Here is an incomplete example (please see `run_async_advanced.py` in examples for something more complete):

--- a/examples/run_async_advanced.py
+++ b/examples/run_async_advanced.py
@@ -1,0 +1,38 @@
+from sanic import Sanic
+from sanic import response
+from signal import signal, SIGINT
+import asyncio
+import uvloop
+
+app = Sanic(__name__)
+
+@app.listener('after_server_start')
+async def after_start_test(app, loop):
+    print("Async Server Started!")
+
+@app.route("/")
+async def test(request):
+    return response.json({"answer": "42"})
+
+asyncio.set_event_loop(uvloop.new_event_loop())
+serv_coro = app.create_server(host="0.0.0.0", port=8000, return_asyncio_server=True)
+loop = asyncio.get_event_loop()
+serv_task = asyncio.ensure_future(serv_coro, loop=loop)
+signal(SIGINT, lambda s, f: loop.stop())
+server = loop.run_until_complete(serv_task)
+server.after_start()
+try:
+    loop.run_forever()
+except KeyboardInterrupt as e:
+    loop.stop()
+finally:
+    server.before_stop()
+
+    # Wait for server to close
+    close_task = server.close()
+    loop.run_until_complete(close_task)
+
+    # Complete all tasks on the loop
+    for connection in server.connections:
+        connection.close_if_idle()
+    server.after_stop()

--- a/tests/test_server_events.py
+++ b/tests/test_server_events.py
@@ -1,3 +1,4 @@
+import asyncio
 import signal
 
 import pytest
@@ -89,3 +90,52 @@ async def test_trigger_before_events_create_server(app):
 
     assert hasattr(app, "db")
     assert isinstance(app.db, MySanicDb)
+
+def test_create_server_trigger_events(app):
+    """Test if create_server can trigger server events"""
+
+    flag1 = False
+    flag2 = False
+    flag3 = False
+
+    async def stop(app, loop):
+        nonlocal flag1
+        flag1 = True
+        await asyncio.sleep(0.1)
+        app.stop()
+
+    async def before_stop(app, loop):
+        nonlocal flag2
+        flag2 = True
+
+    async def after_stop(app, loop):
+        nonlocal flag3
+        flag3 = True
+
+    app.listener("after_server_start")(stop)
+    app.listener("before_server_stop")(before_stop)
+    app.listener("after_server_stop")(after_stop)
+
+    loop = asyncio.get_event_loop()
+    serv_coro = app.create_server(return_asyncio_server=True)
+    serv_task = asyncio.ensure_future(serv_coro, loop=loop)
+    server = loop.run_until_complete(serv_task)
+    server.after_start()
+    try:
+        loop.run_forever()
+    except KeyboardInterrupt as e:
+        loop.stop()
+    finally:
+        # Run the on_stop function if provided
+        server.before_stop()
+
+        # Wait for server to close
+        close_task = server.close()
+        loop.run_until_complete(close_task)
+
+        # Complete all tasks on the loop
+        signal.stopped = True
+        for connection in server.connections:
+            connection.close_if_idle()
+        server.after_stop()
+    assert flag1 and flag2 and flag3


### PR DESCRIPTION
Fixes ability to trigger "after_server_start", "before_server_stop", "after_server_stop" server events when using `app.create_server()` along with `return_asyncio_server=True` to start and manage your own asyncio_server.

See example file `examples/run_async_advanced.py` for a full example.

Related to community forum post: https://community.sanicframework.org/t/triggering-after-server-start-event-when-running-asyncio-server/385