### PR TITLE
Support websockets 8.x as well as 7.x

### DIFF
--- a/sanic/websocket.py
+++ b/sanic/websocket.py
@@ -119,6 +119,9 @@ class WebSocketProtocol(HttpProtocol):
             read_limit=self.websocket_read_limit,
             write_limit=self.websocket_write_limit,
         )
+        # Following two lines are required for websockets 8.x
+        self.websocket.is_client = False
+        self.websocket.side = "server"
         self.websocket.subprotocol = subprotocol
         self.websocket.connection_made(request.transport)
         self.websocket.connection_open()

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ requirements = [
     uvloop,
     ujson,
     "aiofiles>=0.3.0",
-    "websockets>=7.0,<8.0",
+    "websockets>=7.0,<9.0",
     "multidict>=4.0,<5.0",
     "requests-async==0.5.0",
 ]


### PR DESCRIPTION
Sanic currently requires websockets 7.x, but the [changelog for 8.x](https://websockets.readthedocs.io/en/stable/changelog.html) is pretty benign from Sanic's perspective (now that Python 3.5 has been dropped). All that's missing is [a declaration](https://github.com/aaugustin/websockets/blob/master/src/websockets/server.py#L75-L76) whether sanic has the client or server end of the websocket.

Supporting websockets 8.x is required for [nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/python-modules/sanic/default.nix), since this defines a globally consistent set of Python packages that includes 8.x.

I've tested this with a websocket-based sanic app with websockets versions 7.0 and 8.0.2 and it works fine for me.

Thanks for Sanic by the way!