### PR TITLE
Add 'python_requires' key to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup_kwargs = {
     "long_description": long_description,
     "packages": ["sanic"],
     "platforms": "any",
+    "python_requires": ">=3.6",
     "classifiers": [
         "Development Status :: 4 - Beta",
         "Environment :: Web Environment",


### PR DESCRIPTION
This key is important so that `pip` doesn't try to install `sanic` in unsupported Python versions:

https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires