### PR TITLE
Reduce nesting for the sample authentication decorator

### DIFF
--- a/examples/authorized_sanic.py
+++ b/examples/authorized_sanic.py
@@ -13,7 +13,7 @@ def check_request_for_authorization_status(request):
     return flag
 
 
-def authorized():
+def authorized(f):
     @wraps(f)
     async def decorated_function(request, *args, **kwargs):
         # run some method that checks the request

--- a/examples/authorized_sanic.py
+++ b/examples/authorized_sanic.py
@@ -14,27 +14,25 @@ def check_request_for_authorization_status(request):
 
 
 def authorized():
-    def decorator(f):
-        @wraps(f)
-        async def decorated_function(request, *args, **kwargs):
-            # run some method that checks the request
-            # for the client's authorization status
-            is_authorized = check_request_for_authorization_status(request)
+    @wraps(f)
+    async def decorated_function(request, *args, **kwargs):
+        # run some method that checks the request
+        # for the client's authorization status
+        is_authorized = check_request_for_authorization_status(request)
 
-            if is_authorized:
-                # the user is authorized.
-                # run the handler method and return the response
-                response = await f(request, *args, **kwargs)
-                return response
-            else:
-                # the user is not authorized.
-                return json({'status': 'not_authorized'}, 403)
-        return decorated_function
-    return decorator
+        if is_authorized:
+            # the user is authorized.
+            # run the handler method and return the response
+            response = await f(request, *args, **kwargs)
+            return response
+        else:
+            # the user is not authorized.
+            return json({'status': 'not_authorized'}, 403)
+    return decorated_function
 
 
 @app.route("/")
-@authorized()
+@authorized
 async def test(request):
     return json({'status': 'authorized'})
 


### PR DESCRIPTION
The existing example at the Sanic repository uses an outer-most func that takes no args in order to return the decorator itself.

Given no args are being provided, we can go with a plain decorator, which should be even simpler for someone who is starting, i.e., more beginner-friendly.

Higher-level decorators are usually a pain for beginners (at least it was for me when I was one).