### PR TITLE
Fix #1714

### DIFF
--- a/sanic/server.py
+++ b/sanic/server.py
@@ -354,7 +354,11 @@ class HttpProtocol(asyncio.Protocol):
             self.request.body_push(body)
 
     async def body_append(self, body):
-        if self._request_stream_task is None or self._request_stream_task.cancelled():
+        if (
+            self.request is None
+            or self._request_stream_task is None
+            or self._request_stream_task.cancelled()
+        ):
             return
 
         if self.request.stream.is_full():
@@ -601,12 +605,8 @@ class HttpProtocol(asyncio.Protocol):
         self.request = None
         self.url = None
         self.headers = None
-        if self._request_handler_task:
-            self._request_handler_task.cancel()
-            self._request_handler_task = None
-        if self._request_stream_task:
-            self._request_stream_task.cancel()
-            self._request_stream_task = None
+        self._request_handler_task = None
+        self._request_stream_task = None
         self._total_request_size = 0
         self._is_stream_handler = False
 


### PR DESCRIPTION
Fix https://github.com/huge-success/sanic/issues/1714

`AttributeError: 'NoneType' object has no attribute 'stream'`

It happens mainly because the `cleanup` function call (https://github.com/huge-success/sanic/blob/master/sanic/server.py#L593) cleaned `request` context, while the body_append asyncio.task in event loop still relies on that.