### PR TITLE
pass request_buffer_queue_size argument to HttpProtocol

### DIFF
--- a/sanic/request.py
+++ b/sanic/request.py
@@ -62,6 +62,10 @@ class StreamBuffer:
     def is_full(self):
         return self._queue.full()
 
+    @property
+    def buffer_size(self):
+        return self._queue.maxsize
+
 
 class Request:
     """Properties of an HTTP request such as URL, headers, etc."""

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -818,6 +818,7 @@ def serve(
         response_timeout=response_timeout,
         keep_alive_timeout=keep_alive_timeout,
         request_max_size=request_max_size,
+        request_buffer_queue_size=request_buffer_queue_size,
         request_class=request_class,
         access_log=access_log,
         keep_alive=keep_alive,

--- a/tests/test_request_buffer_queue_size.py
+++ b/tests/test_request_buffer_queue_size.py
@@ -1,0 +1,36 @@
+import io
+
+from sanic.response import text
+
+data = "abc" * 10_000_000
+
+
+def test_request_buffer_queue_size(app):
+    default_buf_qsz = app.config.get("REQUEST_BUFFER_QUEUE_SIZE")
+    qsz = 1
+    while qsz == default_buf_qsz:
+        qsz += 1
+    app.config.REQUEST_BUFFER_QUEUE_SIZE = qsz
+
+    @app.post("/post", stream=True)
+    async def post(request):
+        assert request.stream.buffer_size == qsz
+        print("request.stream.buffer_size =", request.stream.buffer_size)
+
+        bio = io.BytesIO()
+        while True:
+            bdata = await request.stream.read()
+            if not bdata:
+                break
+            bio.write(bdata)
+
+            head = bdata[:3].decode("utf-8")
+            tail = bdata[3:][-3:].decode("utf-8")
+            print(head, "...", tail)
+
+        bio.seek(0)
+        return text(bio.read().decode("utf-8"))
+
+    request, response = app.test_client.post("/post", data=data)
+    assert response.status == 200
+    assert response.text == data


### PR DESCRIPTION
REQUEST_BUFFER_QUEUE_SIZE config is just ignored now because it is not passed to HttpProtocol when server starts up. This patch fixes to pass it to HttpProtocol.