### PR TITLE
Allow empty body without Content-Type; Introduce response.empty()

### DIFF
--- a/sanic/response.py
+++ b/sanic/response.py
@@ -153,7 +153,7 @@ class HTTPResponse(BaseHTTPResponse):
         body=None,
         status=200,
         headers=None,
-        content_type="text/plain",
+        content_type=None,
         body_bytes=b"",
     ):
         self.content_type = content_type
@@ -181,9 +181,9 @@ class HTTPResponse(BaseHTTPResponse):
                 "Content-Length", len(self.body)
             )
 
-        self.headers["Content-Type"] = self.headers.get(
-            "Content-Type", self.content_type
-        )
+        # self.headers get priority over content_type
+        if self.content_type and "Content-Type" not in self.headers:
+            self.headers["Content-Type"] = self.content_type
 
         if self.status in (304, 412):
             self.headers = remove_entity_headers(self.headers)
@@ -212,6 +212,18 @@ class HTTPResponse(BaseHTTPResponse):
         if self._cookies is None:
             self._cookies = CookieJar(self.headers)
         return self._cookies
+
+
+def empty(
+    status=204, headers=None,
+):
+    """
+    Returns an empty response to the client.
+
+    :param status Response code.
+    :param headers Custom Headers.
+    """
+    return HTTPResponse(body_bytes=b"", status=status, headers=headers,)
 
 
 def json(

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -21,6 +21,7 @@ from sanic.response import (
     raw,
     stream,
 )
+from sanic.response import empty
 from sanic.server import HttpProtocol
 from sanic.testing import HOST, PORT
 
@@ -591,3 +592,13 @@ def test_raw_response(app):
     request, response = app.test_client.get("/test")
     assert response.content_type == "application/octet-stream"
     assert response.body == b"raw_response"
+
+
+def test_empty_response(app):
+    @app.get("/test")
+    def handler(request):
+        return empty()
+
+    request, response = app.test_client.get("/test")
+    assert response.content_type is None
+    assert response.body == b""


### PR DESCRIPTION
Sometimes, a 204 response is just enough to signal the client what the backend wants to do. Currently, this is possible but has some awkwardness.
First, an empty response has no `Content-Type`, however all responses require Content-Type header.

This PR allows `content_type` param in `HTTPResponse` to be `None`. It is the simplest solution, however I have to say I am not a big fan.
A big disadvantage is the fact that the content type is now located in two locations: `self.headers` and `self.content_type` and they COULD be out of sync, since `headers` have a higher precedence.
This means that if one passes `text/plain` to `content_type` but `Content-Type: application/json` in `headers`, the final result will be an inconsistant response object with one field saying one thing and the other another.

Since this behavior exists before this PR, I did not set out to fix it in this enhancement PR. I personally like to keep PRs atomic, and therefor will contribute a refactor if requested in a sequetial PR.

Fixes https://github.com/huge-success/sanic/issues/1735