### PR TITLE
Simplify status code to text lookup

### DIFF
--- a/sanic/response.py
+++ b/sanic/response.py
@@ -130,12 +130,7 @@ class StreamingHTTPResponse(BaseHTTPResponse):
         )
 
         headers = self._parse_headers()
-
-        if self.status == 200:
-            status = b"OK"
-        else:
-            status = STATUS_CODES.get(self.status)
-
+        status = STATUS_CODES.get(self.status, b"UNKNOWN RESPONSE")
         return (b"HTTP/%b %d %b\r\n" b"%b" b"%b\r\n") % (
             version.encode(),
             self.status,
@@ -189,12 +184,7 @@ class HTTPResponse(BaseHTTPResponse):
             self.headers = remove_entity_headers(self.headers)
 
         headers = self._parse_headers()
-
-        if self.status == 200:
-            status = b"OK"
-        else:
-            status = STATUS_CODES.get(self.status, b"UNKNOWN RESPONSE")
-
+        status = STATUS_CODES.get(self.status, b"UNKNOWN RESPONSE")
         return (
             b"HTTP/%b %d %b\r\n" b"Connection: %b\r\n" b"%b" b"%b\r\n" b"%b"
         ) % (


### PR DESCRIPTION
While working on a followup to https://github.com/huge-success/sanic/pull/1736, I noticed that there's a bizarre check that is redundant. 
Since the map `STATUS_CODES` already contains the staus code of 200, there is no need to check for it specifically. 

This could be done "in the name of performance" but I challenge that fact.