### PR TITLE
Deprecate body_bytes to merge into body

### DIFF
--- a/sanic/response.py
+++ b/sanic/response.py
@@ -149,6 +149,12 @@ class HTTPResponse(BaseHTTPResponse):
         self.headers = Header(headers or {})
         self._cookies = None
 
+        if body_bytes:
+            warnings.warn(
+                "Parameter `body_bytes` is deprecated, use `body` instead",
+                DeprecationWarning,
+            )
+
     def output(self, version="1.1", keep_alive=False, keep_alive_timeout=None):
         body = b""
         if has_message_body(self.status):
@@ -173,7 +179,7 @@ def empty(status=204, headers=None):
     :param status Response code.
     :param headers Custom Headers.
     """
-    return HTTPResponse(body_bytes=b"", status=status, headers=headers)
+    return HTTPResponse(body=b"", status=status, headers=headers)
 
 
 def json(
@@ -243,10 +249,7 @@ def raw(
     :param content_type: the content type (string) of the response.
     """
     return HTTPResponse(
-        body_bytes=body,
-        status=status,
-        headers=headers,
-        content_type=content_type,
+        body=body, status=status, headers=headers, content_type=content_type,
     )
 
 
@@ -306,10 +309,10 @@ async def file(
 
     mime_type = mime_type or guess_type(filename)[0] or "text/plain"
     return HTTPResponse(
+        body=out_stream,
         status=status,
         headers=headers,
         content_type=mime_type,
-        body_bytes=out_stream,
     )
 
 

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,6 +1,7 @@
 import asyncio
 import inspect
 import os
+import warnings
 
 from collections import namedtuple
 from mimetypes import guess_type
@@ -607,3 +608,17 @@ def test_empty_response(app):
     request, response = app.test_client.get("/test")
     assert response.content_type is None
     assert response.body == b""
+
+
+def test_response_body_bytes_deprecated(app):
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+
+        HTTPResponse(body_bytes=b'bytes')
+
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+        assert (
+            "Parameter `body_bytes` is deprecated, use `body` instead"
+            in str(w[0].message)
+        )


### PR DESCRIPTION
As suggested in https://github.com/huge-success/sanic/pull/1736#issuecomment-568266049, this PR deprecates `body_bytes` and merges it into `body`.

Please note that I have intentionally removed the `body_bytes` param completely to elicit discussion about how to properly deprecate it (cc @ahopkins who has some thoughts to share).