### PR TITLE
fix 1748 : Drop DeprecationWarning in python 3.8

### DIFF
--- a/sanic/server.py
+++ b/sanic/server.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import sys
 import traceback
 
 from collections import deque
@@ -133,7 +134,10 @@ class HttpProtocol(asyncio.Protocol):
         self.request_class = request_class or Request
         self.is_request_stream = is_request_stream
         self._is_stream_handler = False
-        self._not_paused = asyncio.Event(loop=loop)
+        if sys.version_info.minor >= 8:
+            self._not_paused = asyncio.Event()
+        else:
+            self._not_paused = asyncio.Event(loop=loop)
         self._total_request_size = 0
         self._request_timeout_handler = None
         self._response_timeout_handler = None
@@ -950,7 +954,10 @@ def serve(
             else:
                 conn.close()
 
-        _shutdown = asyncio.gather(*coros, loop=loop)
+        if sys.version_info.minor >= 8:
+            _shutdown = asyncio.gather(*coros, loop=loop)
+        else:
+            _shutdown = asyncio.gather(*coros)
         loop.run_until_complete(_shutdown)
 
         trigger_events(after_stop, loop)


### PR DESCRIPTION
ref: https://github.com/huge-success/sanic/issues/1748

I'm not sure for python 3.6+ , the loop is omit safely. So, drop the loop specified by version check.
