### PR TITLE
Fix dangling comma in arguments list for HTTPResponse in response.empty()

### DIFF
--- a/sanic/response.py
+++ b/sanic/response.py
@@ -211,7 +211,7 @@ def empty(
     :param status Response code.
     :param headers Custom Headers.
     """
-    return HTTPResponse(body_bytes=b"", status=status, headers=headers,)
+    return HTTPResponse(body_bytes=b"", status=status, headers=headers)
 
 
 def json(

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -202,9 +202,7 @@ class HTTPResponse(BaseHTTPResponse):
         return self._cookies
 
 
-def empty(
-    status=204, headers=None,
-):
+def empty(status=204, headers=None):
     """
     Returns an empty response to the client.
 


### PR DESCRIPTION
Fix dangling comma in arguments list for HTTPResponse in `response.empty()`

Local install of `black` flagged this issue while I was working on a different feature. I don't know why it wasn't picked up when #1736 was tested.