### PR TITLE
Allow route decorators to stack up again

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -194,6 +194,10 @@ class Sanic:
             strict_slashes = self.strict_slashes
 
         def response(handler):
+            if isinstance(handler, (tuple, list)):
+                routes, handler = handler
+            else:
+                routes = []
             args = list(signature(handler).parameters.keys())
 
             if not args:
@@ -205,7 +209,7 @@ class Sanic:
             if stream:
                 handler.is_stream = stream
 
-            routes = self.router.add(
+            new_routes = self.router.add(
                 uri=uri,
                 methods=methods,
                 handler=handler,
@@ -214,6 +218,7 @@ class Sanic:
                 version=version,
                 name=name,
             )
+            routes.extend(new_routes)
             return routes, handler
 
         return response

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -563,6 +563,23 @@ def test_double_stack_route(app):
     assert response.status == 200
 
 
+@pytest.mark.asyncio
+async def test_websocket_route_asgi(app):
+    ev = asyncio.Event()
+
+    @app.websocket("/test/1")
+    @app.websocket("/test/2")
+    async def handler(request, ws):
+        ev.set()
+
+    request, response = await app.asgi_client.websocket("/test/1")
+    first_set = ev.is_set()
+    ev.clear()
+    request, response = await app.asgi_client.websocket("/test/1")
+    second_set = ev.is_set()
+    assert(first_set and second_set)
+
+
 def test_method_not_allowed(app):
     @app.route("/test", methods=["GET"])
     async def handler(request):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -551,6 +551,18 @@ def test_route_duplicate(app):
             pass
 
 
+def test_double_stack_route(app):
+    @app.route("/test/1")
+    @app.route("/test/2")
+    async def handler1(request):
+        return text("OK")
+
+    request, response = app.test_client.get("/test/1")
+    assert response.status == 200
+    request, response = app.test_client.get("/test/2")
+    assert response.status == 200
+
+
 def test_method_not_allowed(app):
     @app.route("/test", methods=["GET"])
     async def handler(request):


### PR DESCRIPTION
A PR:https://github.com/huge-success/sanic/pull/1690 broke the ability to stack route decorators.

This PR will allow again route decorators to stack up without causing a function signature inspection crash
Fix #1742

Also adds a test to detect this breakage, and verify its now fixed, and to ensure it stays fixed in the future.
