### PR TITLE
[Trio] Quick fixes to make Sanic usable on hypercorn -k trio myweb.app

### DIFF
--- a/sanic/compat.py
+++ b/sanic/compat.py
@@ -1,6 +1,24 @@
+from sys import argv
+
 from multidict import CIMultiDict  # type: ignore
 
 
 class Header(CIMultiDict):
     def get_all(self, key):
         return self.getall(key, default=[])
+
+use_trio = argv[0].endswith("hypercorn") and "trio" in argv
+
+if use_trio:
+    from trio import open_file as open_async, Path
+
+    def stat_async(path):
+        return Path(path).stat()
+
+
+else:
+    from aiofiles import open as aio_open
+    from aiofiles.os import stat as stat_async  # type: ignore
+
+    async def open_async(file, mode="r", **kwargs):
+        return aio_open(file, mode, **kwargs)

--- a/sanic/compat.py
+++ b/sanic/compat.py
@@ -10,14 +10,14 @@ class Header(CIMultiDict):
 use_trio = argv[0].endswith("hypercorn") and "trio" in argv
 
 if use_trio:
-    from trio import open_file as open_async, Path
+    from trio import open_file as open_async, Path  # type: ignore
 
     def stat_async(path):
         return Path(path).stat()
 
 
 else:
-    from aiofiles import open as aio_open
+    from aiofiles import open as aio_open  # type: ignore
     from aiofiles.os import stat as stat_async  # type: ignore
 
     async def open_async(file, mode="r", **kwargs):

--- a/sanic/compat.py
+++ b/sanic/compat.py
@@ -7,6 +7,7 @@ class Header(CIMultiDict):
     def get_all(self, key):
         return self.getall(key, default=[])
 
+
 use_trio = argv[0].endswith("hypercorn") and "trio" in argv
 
 if use_trio:
@@ -18,7 +19,7 @@ if use_trio:
 
 else:
     from aiofiles import open as aio_open  # type: ignore
-    from aiofiles.os import stat as stat_async  # type: ignore
+    from aiofiles.os import stat as stat_async  # type: ignore  # noqa: F401
 
     async def open_async(file, mode="r", **kwargs):
         return aio_open(file, mode, **kwargs)

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -3,7 +3,8 @@ from mimetypes import guess_type
 from os import path
 from urllib.parse import quote_plus
 
-from aiofiles import open as open_async  # type: ignore
+#from aiofiles import open as open_async  # type: ignore
+from trio import open_file as open_async
 
 from sanic.compat import Header
 from sanic.cookies import CookieJar
@@ -300,7 +301,7 @@ async def file(
         )
     filename = filename or path.split(location)[-1]
 
-    async with open_async(location, mode="rb") as _file:
+    async with await open_async(location, mode="rb") as _file:
         if _range:
             await _file.seek(_range.start)
             out_stream = await _file.read(_range.size)

--- a/sanic/static.py
+++ b/sanic/static.py
@@ -4,7 +4,10 @@ from re import sub
 from time import gmtime, strftime
 from urllib.parse import unquote
 
-from aiofiles.os import stat  # type: ignore
+#from aiofiles.os import stat  # type: ignore
+from trio import Path
+def stat(path):
+    return Path(path).stat()
 
 from sanic.exceptions import (
     ContentRangeError,

--- a/sanic/static.py
+++ b/sanic/static.py
@@ -4,11 +4,7 @@ from re import sub
 from time import gmtime, strftime
 from urllib.parse import unquote
 
-#from aiofiles.os import stat  # type: ignore
-from trio import Path
-def stat(path):
-    return Path(path).stat()
-
+from sanic.compat import stat_async
 from sanic.exceptions import (
     ContentRangeError,
     FileNotFound,
@@ -87,7 +83,7 @@ def register(
             # and it has not been modified since
             stats = None
             if use_modified_since:
-                stats = await stat(file_path)
+                stats = await stat_async(file_path)
                 modified_since = strftime(
                     "%a, %d %b %Y %H:%M:%S GMT", gmtime(stats.st_mtime)
                 )
@@ -98,7 +94,7 @@ def register(
             if use_content_range:
                 _range = None
                 if not stats:
-                    stats = await stat(file_path)
+                    stats = await stat_async(file_path)
                 headers["Accept-Ranges"] = "bytes"
                 headers["Content-Length"] = str(stats.st_size)
                 if request.method != "HEAD":
@@ -123,7 +119,7 @@ def register(
                         threshold = 1024 * 1024
 
                     if not stats:
-                        stats = await stat(file_path)
+                        stats = await stat_async(file_path)
                     if stats.st_size >= threshold:
                         return await file_stream(
                             file_path, headers=headers, _range=_range


### PR DESCRIPTION
Quite surprisingly it only took a few lines of changes to make Sanic run on Trio (with Trio-using webapp), on top of Hypercorn. If it is that easy, I'd like to include this in mainline, provided that it can be configured in some smart way (the first commit lacks configuration).

Is there some way that the library could be chosen at module load time, to avoid importing aiofiles when running on trio?

