### PR TITLE
Fix #1788 incorrect url_for for routes with hosts, added tests.

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -832,7 +832,7 @@ class Sanic:
 
         # If the route has host defined, split that off
         # TODO: Retain netloc and path separately in Route objects
-        host = uri.find('/')
+        host = uri.find("/")
         if host > 0:
             host, uri = uri[:host], uri[host:]
         else:

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -929,7 +929,7 @@ class Sanic:
         query_string = urlencode(kwargs, doseq=True) if kwargs else ""
         # scheme://netloc/path;parameters?query#fragment
         out = urlunparse((scheme, netloc, out, "", query_string, anchor))
-        print(out)
+
         return out
 
     # -------------------------------------------------------------------- #

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -830,6 +830,14 @@ class Sanic:
                 "Endpoint with name `{}` was not found".format(view_name)
             )
 
+        # If the route has host defined, split that off
+        # TODO: Retain netloc and path separately in Route objects
+        host = uri.find('/')
+        if host > 0:
+            host, uri = uri[:host], uri[host:]
+        else:
+            host = None
+
         if view_name == "static" or view_name.endswith(".static"):
             filename = kwargs.pop("filename", None)
             # it's static folder
@@ -862,7 +870,7 @@ class Sanic:
 
         netloc = kwargs.pop("_server", None)
         if netloc is None and external:
-            netloc = self.config.get("SERVER_NAME", "")
+            netloc = host or self.config.get("SERVER_NAME", "")
 
         if external:
             if not scheme:
@@ -921,7 +929,7 @@ class Sanic:
         query_string = urlencode(kwargs, doseq=True) if kwargs else ""
         # scheme://netloc/path;parameters?query#fragment
         out = urlunparse((scheme, netloc, out, "", query_string, anchor))
-
+        print(out)
         return out
 
     # -------------------------------------------------------------------- #

--- a/tests/test_url_for.py
+++ b/tests/test_url_for.py
@@ -1,0 +1,12 @@
+def test_routes_with_host(app):
+    @app.route("/")
+    @app.route("/", name="hostindex", host="example.com")
+    @app.route("/path", name="hostpath", host="path.example.com")
+    def index(request):
+        pass
+
+    assert app.url_for("index") == "/"
+    assert app.url_for("hostindex") == "/"
+    assert app.url_for("hostpath") == "/path"
+    assert app.url_for("hostindex", _external=True) == "http://example.com/"
+    assert app.url_for("hostpath", _external=True) == "http://path.example.com/path"


### PR DESCRIPTION
The router allows specifying different hostname for specific routes, and handles this internally by string concatenation of host and path into uri, confusing `app.url_for` into creating invalid URLs.

Ultimately it would be more sensible to keep URL and path separately in Router objects, but as a workaround to the mentioned bug report, this is now handled in `url_for` which uses any route-provided host where `SERVER_NAME` would otherwise be used.

Adds `test_url_for.py` to avoid regressions, and to allow for more comprehensive testing of the said function, which doesn't seem to be currently tested properly.

Fixes issue #1788 