### PR TITLE
Protocol errors did not support async error handlers

### DIFF
--- a/sanic/server.py
+++ b/sanic/server.py
@@ -567,7 +567,7 @@ class HttpProtocol(asyncio.Protocol):
                 self.cleanup()
 
     def write_error(self, exception):
-        asyncio.create_task(self.write_error_async(exception))
+        self.loop.create_task(self.write_error_async(exception))
 
     async def write_error_async(self, exception):
         # An error _is_ a response.

--- a/tests/test_payload_too_large.py
+++ b/tests/test_payload_too_large.py
@@ -18,6 +18,22 @@ def test_payload_too_large_from_error_handler(app):
     assert response.text == "Payload Too Large from error_handler."
 
 
+def test_payload_too_large_from_async_error_handler(app):
+    app.config.REQUEST_MAX_SIZE = 1
+
+    @app.route("/1")
+    async def handler1(request):
+        return text("OK")
+
+    @app.exception(PayloadTooLarge)
+    async def handler_exception(request, exception):
+        return text("Payload Too Large from error_handler.", 413)
+
+    response = app.test_client.get("/1", gather_request=False)
+    assert response.status == 413
+    assert response.text == "Payload Too Large from error_handler."
+
+
 def test_payload_too_large_at_data_received_default(app):
     app.config.REQUEST_MAX_SIZE = 1
 


### PR DESCRIPTION
Fix async error handlers which were not being awaited when errors occurred within protocol code (e.g. Payload Too Large).

This appears to be working but I did not review what consequences does it have that `server.write_error` is now in fact asynchronous.

Issue #1785 
