### PR TITLE
Allow multiple workers on MacOS with Python 3.8

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -1096,7 +1096,7 @@ class Sanic:
         stop_event: Any = None,
         register_sys_signals: bool = True,
         access_log: Optional[bool] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         """Run the HTTP Server and listen until keyboard interrupt or term
         signal. On termination, drain connections before closing.
@@ -1177,6 +1177,12 @@ class Sanic:
 
         try:
             self.is_running = True
+            if workers > 1 and os.name != "posix":
+                logger.warn(
+                    f"Multiprocessing is currently not supported on {os.name},"
+                    " using workers=1 instead"
+                )
+                workers = 1
             if workers == 1:
                 if auto_reload and os.name != "posix":
                     # This condition must be removed after implementing

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -1,4 +1,5 @@
 import asyncio
+import multiprocessing
 import os
 import sys
 import traceback
@@ -6,7 +7,6 @@ import traceback
 from collections import deque
 from functools import partial
 from inspect import isawaitable
-from multiprocessing import Process
 from signal import SIG_IGN, SIGINT, SIGTERM, Signals
 from signal import signal as signal_func
 from socket import SO_REUSEADDR, SOL_SOCKET, socket
@@ -1017,9 +1017,10 @@ def serve_multiple(server_settings, workers):
 
     signal_func(SIGINT, lambda s, f: sig_handler(s, f))
     signal_func(SIGTERM, lambda s, f: sig_handler(s, f))
+    mp = multiprocessing.get_context("fork")
 
     for _ in range(workers):
-        process = Process(target=serve, kwargs=server_settings)
+        process = mp.Process(target=serve, kwargs=server_settings)
         process.daemon = True
         process.start()
         processes.append(process)


### PR DESCRIPTION
The app object cannot be pickled, apparently due to it containing decorated route functions and the decorator wrapper cannot be passed to worker processes. This became a bigger issue with Python 3.8 that made spawn mode the default of multiprocessing on MacOS, causing workers > 1 to stop working.

This patch forces fork mode on POSIX systems (*nix, MacOS) because it doesn't pickle, and on other systems (Windows) issues a warning and sets `workers=1`.

The proper fix would be to rewrite process spawning so that app object is initialised separately in each worker, not passed via pickling, but I doubt anyone will have time to implement that.
