### PR TITLE
Remove the old request context API (for 20.3 release)

### DIFF
--- a/sanic/request.py
+++ b/sanic/request.py
@@ -127,31 +127,6 @@ class Request:
             self.__class__.__name__, self.method, self.path
         )
 
-    def get(self, key, default=None):
-        """.. deprecated:: 19.9
-           Custom context is now stored in `request.custom_context.yourkey`"""
-        return self.ctx.__dict__.get(key, default)
-
-    def __contains__(self, key):
-        """.. deprecated:: 19.9
-           Custom context is now stored in `request.custom_context.yourkey`"""
-        return key in self.ctx.__dict__
-
-    def __getitem__(self, key):
-        """.. deprecated:: 19.9
-           Custom context is now stored in `request.custom_context.yourkey`"""
-        return self.ctx.__dict__[key]
-
-    def __delitem__(self, key):
-        """.. deprecated:: 19.9
-           Custom context is now stored in `request.custom_context.yourkey`"""
-        del self.ctx.__dict__[key]
-
-    def __setitem__(self, key, value):
-        """.. deprecated:: 19.9
-           Custom context is now stored in `request.custom_context.yourkey`"""
-        setattr(self.ctx, key, value)
-
     def body_init(self):
         self.body = []
 

--- a/tests/test_request_data.py
+++ b/tests/test_request_data.py
@@ -44,44 +44,6 @@ def test_custom_context(app):
     }
 
 
-# Remove this once the deprecated API is abolished.
-def test_custom_context_old(app):
-    @app.middleware("request")
-    def store(request):
-        try:
-            request["foo"]
-        except KeyError:
-            pass
-        request["user"] = "sanic"
-        sidekick = request.get("sidekick", "tails")  # Item missing -> default
-        request["sidekick"] = sidekick
-        request["bar"] = request["sidekick"]
-        del request["sidekick"]
-
-    @app.route("/")
-    def handler(request):
-        return json(
-            {
-                "user": request.get("user"),
-                "sidekick": request.get("sidekick"),
-                "has_bar": "bar" in request,
-                "has_sidekick": "sidekick" in request,
-            }
-        )
-
-    request, response = app.test_client.get("/")
-
-    assert response.json == {
-        "user": "sanic",
-        "sidekick": None,
-        "has_bar": True,
-        "has_sidekick": False,
-    }
-    response_json = loads(response.text)
-    assert response_json["user"] == "sanic"
-    assert response_json.get("sidekick") is None
-
-
 def test_app_injection(app):
     expected = random.choice(range(0, 100))
 


### PR DESCRIPTION
Storing context directly on the request object has been deprecated since 19.9, in favour of `request.ctx` in #1666, and these compatibility functions should be no longer needed.
