### PR TITLE
Update docs for order of listeners

### DIFF
--- a/docs/sanic/middleware.rst
+++ b/docs/sanic/middleware.rst
@@ -132,6 +132,17 @@ For example:
     async def close_db(app, loop):
         await app.db.close()
 
+Note:
+
+The listeners are deconstructed in the reverse order of being constructed.
+
+For example:
+
+If the first listener in before_server_start handler setups a database connection,
+ones registered after it can rely on that connection being alive both when they are started
+and stopped, because stopping is done in reverse order, and the database connection is
+torn down last.
+
 It's also possible to register a listener using the `register_listener` method.
 This may be useful if you define your listeners in another module besides
 the one you instantiate your app in.


### PR DESCRIPTION
Added comments in the middleware listener section to highlight the order. 
https://github.com/huge-success/sanic/issues/1610