### PR TITLE
Import ASGIDispatch from top-level httpx

### DIFF
--- a/sanic/testing.py
+++ b/sanic/testing.py
@@ -185,7 +185,7 @@ async def app_call_with_return(self, scope, receive, send):
     return await asgi_app()
 
 
-class SanicASGIDispatch(httpx.dispatch.asgi.ASGIDispatch):
+class SanicASGIDispatch(httpx.ASGIDispatch):
     pass
 
 


### PR DESCRIPTION
Importing from submodules of httpx is deprecated since 0.11.0 and removed in 0.12.0.

Fix #1786