### PR TITLE
Avoid py38 test failure on Windows

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -48,6 +48,7 @@ def test_asyncio_server_no_start_serving(app):
     if not uvloop_installed():
         loop = asyncio.get_event_loop()
         asyncio_srv_coro = app.create_server(
+            port=43123,
             return_asyncio_server=True,
             asyncio_server_kwargs=dict(start_serving=False),
         )
@@ -61,6 +62,7 @@ def test_asyncio_server_start_serving(app):
     if not uvloop_installed():
         loop = asyncio.get_event_loop()
         asyncio_srv_coro = app.create_server(
+            port=43124,
             return_asyncio_server=True,
             asyncio_server_kwargs=dict(start_serving=False),
         )

--- a/tests/test_request_stream.py
+++ b/tests/test_request_stream.py
@@ -8,7 +8,7 @@ from sanic.views import CompositionView, HTTPMethodView
 from sanic.views import stream as stream_decorator
 
 
-data = "abc" * 10000000
+data = "abc" * 1_000_000
 
 
 def test_request_stream_method_view(app):


### PR DESCRIPTION
Reduces test data size to 3 MB instead of 30 MB. This should not affect what the tests are trying to accomplish but makes them run faster, which apparently was an issue on Windows until now. Each test includes a large number of requests each of which include this data, and I could get all of them passing if I commented out some of the others, without reducing data size.

Reducing data size makes the tests run much faster and now they pass on my Windows virtual machine with all requests enabled.