### PR TITLE
Fallback to psutil when /proc/.../children isn't present

### DIFF
--- a/sanic/reloader_helpers.py
+++ b/sanic/reloader_helpers.py
@@ -2,7 +2,6 @@ import os
 import signal
 import subprocess
 import sys
-
 from multiprocessing import Process
 from time import sleep
 
@@ -74,7 +73,15 @@ def kill_process_children_unix(pid):
     """
     root_process_path = f"/proc/{pid}/task/{pid}/children"
     if not os.path.isfile(root_process_path):
+        # Fall back to psutils
+        # Ubuntu 18.04 WSL2 doesn't have .../task/pid/children
+        import psutil
+
+        ppid = psutil.Process(pid)
+        for children in ppid.children(recursive=True):
+            os.kill(int(children.pid), signal.SIGTERM)
         return
+
     with open(root_process_path) as children_list_file:
         children_list_pid = children_list_file.read().split()
 

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ requirements = [
     "websockets>=7.0,<9.0",
     "multidict>=4.0,<5.0",
     "httpx==0.11.1",
+    "psutil>=5.7.0"
 ]
 
 tests_require = [


### PR DESCRIPTION
I'm developing a project using Ubuntu 18.04 on Windows WSL2. For some reason `/proc/{pid}/task/{pid}/children` isn't available. When this happened, we return with no good explanation why.

To make sure we don't break current users, I added a fallback to psutil to discover the children and kill them and move on. 

Hope this helps others who use WSL2


Edit: This affects the live reloading feature