### PR TITLE
Add sanic as an entry point command

### DIFF
--- a/sanic/__main__.py
+++ b/sanic/__main__.py
@@ -1,3 +1,5 @@
+import os
+import sys
 from argparse import ArgumentParser
 from importlib import import_module
 from typing import Any, Dict, Optional
@@ -6,7 +8,7 @@ from sanic.app import Sanic
 from sanic.log import logger
 
 
-if __name__ == "__main__":
+def main():
     parser = ArgumentParser(prog="sanic")
     parser.add_argument("--host", dest="host", type=str, default="127.0.0.1")
     parser.add_argument("--port", dest="port", type=int, default=8000)
@@ -22,6 +24,10 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     try:
+        module_path = os.path.abspath(os.getcwd())
+        if module_path not in sys.path:
+            sys.path.append(module_path)
+
         module_parts = args.module.split(".")
         module_name = ".".join(module_parts[:-1])
         app_name = module_parts[-1]
@@ -58,3 +64,7 @@ if __name__ == "__main__":
         )
     except ValueError:
         logger.exception("Failed to run app")
+
+
+if __name__ == "__main__":
+    main()

--- a/sanic/__main__.py
+++ b/sanic/__main__.py
@@ -1,5 +1,6 @@
 import os
 import sys
+
 from argparse import ArgumentParser
 from importlib import import_module
 from typing import Any, Dict, Optional

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ import codecs
 import os
 import re
 import sys
-
 from distutils.util import strtobool
 
 from setuptools import setup
@@ -39,9 +38,7 @@ def open_local(paths, mode="r", encoding="utf8"):
 
 with open_local(["sanic", "__version__.py"], encoding="latin1") as fp:
     try:
-        version = re.findall(
-            r"^__version__ = \"([^']+)\"\r?$", fp.read(), re.M
-        )[0]
+        version = re.findall(r"^__version__ = \"([^']+)\"\r?$", fp.read(), re.M)[0]
     except IndexError:
         raise RuntimeError("Unable to determine version.")
 
@@ -70,11 +67,10 @@ setup_kwargs = {
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
     ],
+    "entry_points": {"console_scripts": ["sanic = sanic.__main__:main"]},
 }
 
-env_dependency = (
-    '; sys_platform != "win32" ' 'and implementation_name == "cpython"'
-)
+env_dependency = '; sys_platform != "win32" ' 'and implementation_name == "cpython"'
 ujson = "ujson>=1.35" + env_dependency
 uvloop = "uvloop>=0.5.3" + env_dependency
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -56,6 +56,7 @@ def test_asyncio_server_no_start_serving(app):
         srv = loop.run_until_complete(asyncio_srv_coro)
         assert srv.is_serving() is False
 
+
 @pytest.mark.skipif(
     sys.version_info < (3, 7), reason="requires python3.7 or higher"
 )
@@ -74,6 +75,7 @@ def test_asyncio_server_start_serving(app):
         wait_close = srv.close()
         loop.run_until_complete(wait_close)
         # Looks like we can't easily test `serve_forever()`
+
 
 def test_app_loop_not_running(app):
     with pytest.raises(SanicException) as excinfo:
@@ -125,7 +127,10 @@ def test_app_handle_request_handler_is_none(app, monkeypatch):
 
     request, response = app.test_client.get("/test")
 
-    assert "'None' was returned while requesting a handler from the router" in response.text
+    assert (
+        "'None' was returned while requesting a handler from the router"
+        in response.text
+    )
 
 
 @pytest.mark.parametrize("websocket_enabled", [True, False])

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -84,8 +84,8 @@ def test_listeners_triggered(app):
 
     all_tasks = (
         asyncio.Task.all_tasks()
-        if sys.version_info < (3, 7) else
-        asyncio.all_tasks(asyncio.get_event_loop())
+        if sys.version_info < (3, 7)
+        else asyncio.all_tasks(asyncio.get_event_loop())
     )
     for task in all_tasks:
         task.cancel()
@@ -134,8 +134,8 @@ def test_listeners_triggered_async(app):
 
     all_tasks = (
         asyncio.Task.all_tasks()
-        if sys.version_info < (3, 7) else
-        asyncio.all_tasks(asyncio.get_event_loop())
+        if sys.version_info < (3, 7)
+        else asyncio.all_tasks(asyncio.get_event_loop())
     )
     for task in all_tasks:
         task.cancel()

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -270,24 +270,31 @@ def test_bp_middleware(app):
     assert response.status == 200
     assert response.text == "FAIL"
 
+
 def test_bp_middleware_order(app):
     blueprint = Blueprint("test_bp_middleware_order")
     order = list()
+
     @blueprint.middleware("request")
     def mw_1(request):
         order.append(1)
+
     @blueprint.middleware("request")
     def mw_2(request):
         order.append(2)
+
     @blueprint.middleware("request")
     def mw_3(request):
         order.append(3)
+
     @blueprint.middleware("response")
     def mw_4(request, response):
         order.append(6)
+
     @blueprint.middleware("response")
     def mw_5(request, response):
         order.append(5)
+
     @blueprint.middleware("response")
     def mw_6(request, response):
         order.append(4)
@@ -302,6 +309,7 @@ def test_bp_middleware_order(app):
 
     assert response.status == 200
     assert order == [1, 2, 3, 4, 5, 6]
+
 
 def test_bp_exception_handler(app):
     blueprint = Blueprint("test_middleware")
@@ -585,9 +593,7 @@ def test_bp_group_with_default_url_prefix(app):
     from uuid import uuid4
 
     resource_id = str(uuid4())
-    request, response = app.test_client.get(
-        f"/api/v1/resources/{resource_id}"
-    )
+    request, response = app.test_client.get(f"/api/v1/resources/{resource_id}")
     assert response.json == {"resource_id": resource_id}
 
 

--- a/tests/test_keep_alive_timeout.py
+++ b/tests/test_keep_alive_timeout.py
@@ -9,6 +9,7 @@ from sanic import Sanic, server
 from sanic.response import text
 from sanic.testing import HOST, SanicTestClient
 
+
 CONFIG_FOR_TESTS = {"KEEP_ALIVE_TIMEOUT": 2, "KEEP_ALIVE": True}
 
 old_conn = None
@@ -46,7 +47,7 @@ class ReusableSanicConnectionPool(
                 cert=self.cert,
                 verify=self.verify,
                 trust_env=self.trust_env,
-                http2=self.http2
+                http2=self.http2,
             )
             connection = httpx.dispatch.connection.HTTPConnection(
                 origin,
@@ -166,9 +167,7 @@ class ReuseableSanicTestClient(SanicTestClient):
             try:
                 return results[-1]
             except Exception:
-                raise ValueError(
-                    f"Request object expected, got ({results})"
-                )
+                raise ValueError(f"Request object expected, got ({results})")
 
     def kill_server(self):
         try:

--- a/tests/test_request_stream.py
+++ b/tests/test_request_stream.py
@@ -614,6 +614,7 @@ def test_request_stream(app):
     assert response.status == 200
     assert response.text == data
 
+
 def test_streaming_new_api(app):
     @app.post("/non-stream")
     async def handler(request):

--- a/tests/test_request_timeout.py
+++ b/tests/test_request_timeout.py
@@ -17,7 +17,7 @@ class DelayableHTTPConnection(httpx.dispatch.connection.HTTPConnection):
     async def send(self, request, timeout=None):
 
         if self.connection is None:
-            self.connection = (await self.connect(timeout=timeout))
+            self.connection = await self.connect(timeout=timeout)
 
         if self._request_delay:
             await asyncio.sleep(self._request_delay)

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -242,7 +242,7 @@ def test_non_chunked_streaming_adds_correct_headers(non_chunked_streaming_app):
 
 
 def test_non_chunked_streaming_returns_correct_content(
-    non_chunked_streaming_app
+    non_chunked_streaming_app,
 ):
     request, response = non_chunked_streaming_app.test_client.get("/")
     assert response.text == "foo,bar"
@@ -257,7 +257,7 @@ def test_stream_response_status_returns_correct_headers(status):
 
 @pytest.mark.parametrize("keep_alive_timeout", [10, 20, 30])
 def test_stream_response_keep_alive_returns_correct_headers(
-    keep_alive_timeout
+    keep_alive_timeout,
 ):
     response = StreamingHTTPResponse(sample_streaming_fn)
     headers = response.get_headers(
@@ -286,7 +286,7 @@ def test_stream_response_does_not_include_chunked_header_if_disabled():
 
 
 def test_stream_response_writes_correct_content_to_transport_when_chunked(
-    streaming_app
+    streaming_app,
 ):
     response = StreamingHTTPResponse(sample_streaming_fn)
     response.protocol = MagicMock(HttpProtocol)
@@ -434,9 +434,10 @@ def test_file_response_custom_filename(
     request, response = app.test_client.get(f"/files/{source}")
     assert response.status == 200
     assert response.body == get_file_content(static_file_directory, source)
-    assert response.headers[
-        "Content-Disposition"
-    ] == f'attachment; filename="{dest}"'
+    assert (
+        response.headers["Content-Disposition"]
+        == f'attachment; filename="{dest}"'
+    )
 
 
 @pytest.mark.parametrize("file_name", ["test.file", "decode me.txt"])
@@ -510,9 +511,10 @@ def test_file_stream_response_custom_filename(
     request, response = app.test_client.get(f"/files/{source}")
     assert response.status == 200
     assert response.body == get_file_content(static_file_directory, source)
-    assert response.headers[
-        "Content-Disposition"
-    ] == f'attachment; filename="{dest}"'
+    assert (
+        response.headers["Content-Disposition"]
+        == f'attachment; filename="{dest}"'
+    )
 
 
 @pytest.mark.parametrize("file_name", ["test.file", "decode me.txt"])
@@ -581,7 +583,10 @@ def test_file_stream_response_range(
     request, response = app.test_client.get(f"/files/{file_name}")
     assert response.status == 206
     assert "Content-Range" in response.headers
-    assert response.headers["Content-Range"] == f"bytes {range.start}-{range.end}/{range.total}"
+    assert (
+        response.headers["Content-Range"]
+        == f"bytes {range.start}-{range.end}/{range.total}"
+    )
 
 
 def test_raw_response(app):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -580,7 +580,7 @@ async def test_websocket_route_asgi(app):
     ev.clear()
     request, response = await app.asgi_client.websocket("/test/1")
     second_set = ev.is_set()
-    assert(first_set and second_set)
+    assert first_set and second_set
 
 
 def test_method_not_allowed(app):

--- a/tests/test_signal_handlers.py
+++ b/tests/test_signal_handlers.py
@@ -33,9 +33,7 @@ def after(app, loop):
     calledq.put(mock.called)
 
 
-@pytest.mark.skipif(
-    os.name == "nt", reason="May hang CI on py38/windows"
-)
+@pytest.mark.skipif(os.name == "nt", reason="May hang CI on py38/windows")
 def test_register_system_signals(app):
     """Test if sanic register system signals"""
 
@@ -51,9 +49,7 @@ def test_register_system_signals(app):
     assert calledq.get() is True
 
 
-@pytest.mark.skipif(
-    os.name == "nt", reason="May hang CI on py38/windows"
-)
+@pytest.mark.skipif(os.name == "nt", reason="May hang CI on py38/windows")
 def test_dont_register_system_signals(app):
     """Test if sanic don't register system signals"""
 
@@ -69,9 +65,7 @@ def test_dont_register_system_signals(app):
     assert calledq.get() is False
 
 
-@pytest.mark.skipif(
-    os.name == "nt", reason="windows cannot SIGINT processes"
-)
+@pytest.mark.skipif(os.name == "nt", reason="windows cannot SIGINT processes")
 def test_windows_workaround():
     """Test Windows workaround (on any other OS)"""
     # At least some code coverage, even though this test doesn't work on

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -97,9 +97,7 @@ def test_static_file_content_type(app, static_file_directory, file_name):
 def test_static_directory(app, file_name, base_uri, static_file_directory):
     app.static(base_uri, static_file_directory)
 
-    request, response = app.test_client.get(
-        uri=f"{base_uri}/{file_name}"
-    )
+    request, response = app.test_client.get(uri=f"{base_uri}/{file_name}")
     assert response.status == 200
     assert response.body == get_file_content(static_file_directory, file_name)
 

--- a/tests/test_url_for.py
+++ b/tests/test_url_for.py
@@ -9,4 +9,7 @@ def test_routes_with_host(app):
     assert app.url_for("hostindex") == "/"
     assert app.url_for("hostpath") == "/path"
     assert app.url_for("hostindex", _external=True) == "http://example.com/"
-    assert app.url_for("hostpath", _external=True) == "http://path.example.com/path"
+    assert (
+        app.url_for("hostpath", _external=True)
+        == "http://path.example.com/path"
+    )

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -151,8 +151,7 @@ def test_with_custom_class_methods(app):
         def get(self, request):
             self._iternal_method()
             return text(
-                f"I am get method and global var "
-                f"is {self.global_var}"
+                f"I am get method and global var " f"is {self.global_var}"
             )
 
     app.add_route(DummyView.as_view(), "/")

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -128,8 +128,10 @@ def test_handle_quit(worker):
     assert not worker.alive
     assert worker.exit_code == 0
 
+
 async def _a_noop(*a, **kw):
     pass
+
 
 def test_run_max_requests_exceeded(worker):
     loop = asyncio.new_event_loop()


### PR DESCRIPTION
One thing that I have always thought missing was this:

```
$ sanic server.app --port=5000 --workers=4
```

Since we already have...

```
$ python -m sanic server.app --port=5000 --workers=4
```

... this PR just goes one step further to adding the entrypoint to run the Sanic server with the `sanic` command.