### PR TITLE
Add handler names for websockets for url_for usage

### DIFF
--- a/sanic/blueprints.py
+++ b/sanic/blueprints.py
@@ -283,6 +283,13 @@ class Blueprint:
             strict_slashes = self.strict_slashes
 
         def decorator(handler):
+            nonlocal uri
+            nonlocal host
+            nonlocal strict_slashes
+            nonlocal version
+            nonlocal name
+
+            name = f"{self.name}.{name or handler.__name__}"
             route = FutureRoute(
                 handler, uri, [], host, strict_slashes, False, version, name
             )

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -253,7 +253,11 @@ def test_several_bp_with_host(app):
 
 
 def test_bp_with_host_list(app):
-    bp = Blueprint("test_bp_host", url_prefix="/test1", host=["example.com", "sub.example.com"])
+    bp = Blueprint(
+        "test_bp_host",
+        url_prefix="/test1",
+        host=["example.com", "sub.example.com"],
+    )
 
     @bp.route("/")
     def handler1(request):
@@ -279,8 +283,16 @@ def test_bp_with_host_list(app):
 
 
 def test_several_bp_with_host_list(app):
-    bp = Blueprint("test_text", url_prefix="/test", host=["example.com", "sub.example.com"])
-    bp2 = Blueprint("test_text2", url_prefix="/test", host=["sub1.example.com", "sub2.example.com"])
+    bp = Blueprint(
+        "test_text",
+        url_prefix="/test",
+        host=["example.com", "sub.example.com"],
+    )
+    bp2 = Blueprint(
+        "test_text2",
+        url_prefix="/test",
+        host=["sub1.example.com", "sub2.example.com"],
+    )
 
     @bp.route("/")
     def handler(request):

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -88,10 +88,11 @@ def test_pickle_app_with_bp(app, protocol):
     assert up_p_app.is_request_stream is False
     assert response.text == "Hello"
 
+
 @pytest.mark.parametrize("protocol", [3, 4])
 def test_pickle_app_with_static(app, protocol):
     app.route("/")(handler)
-    app.static('/static', "/tmp/static")
+    app.static("/static", "/tmp/static")
     p_app = pickle.dumps(app, protocol=protocol)
     del app
     up_p_app = pickle.loads(p_app)

--- a/tests/test_reloader.py
+++ b/tests/test_reloader.py
@@ -1,8 +1,8 @@
 import os
 import secrets
 import sys
-from contextlib import suppress
 
+from contextlib import suppress
 from subprocess import PIPE, Popen, TimeoutExpired
 from tempfile import TemporaryDirectory
 from textwrap import dedent
@@ -23,16 +23,20 @@ try:
 except ImportError:
     flags = 0
 
+
 def terminate(proc):
     if flags:
         proc.send_signal(CTRL_BREAK_EVENT)
     else:
         proc.terminate()
 
+
 def write_app(filename, **runargs):
     text = secrets.token_urlsafe()
     with open(filename, "w") as f:
-        f.write(dedent(f"""\
+        f.write(
+            dedent(
+                f"""\
             import os
             from sanic import Sanic
 
@@ -45,8 +49,10 @@ def write_app(filename, **runargs):
             if __name__ == "__main__":
                 app.run(**{runargs!r})
             """
-        ))
+            )
+        )
     return text
+
 
 def scanner(proc):
     for line in proc.stdout:
@@ -59,14 +65,26 @@ def scanner(proc):
 argv = dict(
     script=[sys.executable, "reloader.py"],
     module=[sys.executable, "-m", "reloader"],
-    sanic=[sys.executable, "-m", "sanic", "--port", "42104", "--debug", "reloader.app"],
+    sanic=[
+        sys.executable,
+        "-m",
+        "sanic",
+        "--port",
+        "42104",
+        "--debug",
+        "reloader.app",
+    ],
 )
 
-@pytest.mark.parametrize("runargs, mode", [
-    (dict(port=42102, auto_reload=True), "script"),
-    (dict(port=42103, debug=True), "module"),
-    (dict(), "sanic"),
-])
+
+@pytest.mark.parametrize(
+    "runargs, mode",
+    [
+        (dict(port=42102, auto_reload=True), "script"),
+        (dict(port=42103, debug=True), "module"),
+        (dict(), "sanic"),
+    ],
+)
 async def test_reloader_live(runargs, mode):
     with TemporaryDirectory() as tmpdir:
         filename = os.path.join(tmpdir, "reloader.py")

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -614,7 +614,7 @@ def test_response_body_bytes_deprecated(app):
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
 
-        HTTPResponse(body_bytes=b'bytes')
+        HTTPResponse(body_bytes=b"bytes")
 
         assert len(w) == 1
         assert issubclass(w[0].category, DeprecationWarning)


### PR DESCRIPTION
Accomplishes what #1696 set out to do, but was unable after change to #1853 