### PR TITLE
Test response-middleware in the `request_data` context tests.

### DIFF
--- a/tests/test_request_data.py
+++ b/tests/test_request_data.py
@@ -33,6 +33,23 @@ def test_custom_context(app):
             }
         )
 
+    @app.middleware("response")
+    def modify(request, response):
+        # Using response-middleware to access request ctx
+        try:
+            user = request.ctx.user
+        except AttributeError as e:
+            user = str(e)
+        try:
+            invalid = request.ctx.missing
+        except AttributeError as e:
+            invalid = str(e)
+
+        j = loads(response.body)
+        j['response_mw_valid'] = user
+        j['response_mw_invalid'] = invalid
+        return json(j)
+
     request, response = app.test_client.get("/")
     assert response.json == {
         "user": "sanic",
@@ -41,6 +58,9 @@ def test_custom_context(app):
         "has_session": True,
         "has_missing": False,
         "invalid": "'types.SimpleNamespace' object has no attribute 'missing'",
+        "response_mw_valid": "sanic",
+        "response_mw_invalid":
+            "'types.SimpleNamespace' object has no attribute 'missing'"
     }
 
 


### PR DESCRIPTION
Add an additional step to the request_data context test. This checks if items stored a request.ctx are able to be accessed from a response-middleware after a response is issued.

This is to help debug and reproduce the error described by user `verdebirth` here: https://community.sanicframework.org/t/issue-with-request-ctx-in-response-middleware/611
