### PR TITLE
Adjust isort options and invocation to work with isort 5.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,11 +11,9 @@ line_length = 79
 lines_after_imports = 2
 lines_between_types = 1
 multi_line_output = 3
-not_skip = __init__.py
 
 [version]
 current_version = 19.12.0
 files = sanic/__version__.py
 current_version_pattern = __version__ = "{current_version}"
 new_version_pattern = __version__ = "{new_version}"
-

--- a/tox.ini
+++ b/tox.ini
@@ -30,13 +30,13 @@ commands =
 deps =
     flake8
     black
-    isort
+    isort>=5.0.0
     bandit
 
 commands =
     flake8 sanic
     black --config ./.black.toml --check --verbose sanic/
-    isort --check-only --recursive sanic
+    isort --check-only sanic
 
 [testenv:type-checking]
 deps =


### PR DESCRIPTION
isort 5.0.0 removed command line option `recursive` and removed config option `not_skip`.

This fixes #1889