### PR TITLE
making default reponse text, with optional formatting to be passed

### DIFF
--- a/sanic/errorpages.py
+++ b/sanic/errorpages.py
@@ -35,22 +35,9 @@ def exception_response(request, exception, debug):
     text = escape(text)
 
     if debug and not getattr(exception, "quiet", False):
-        return html(
-            f"<!DOCTYPE html><meta charset=UTF-8><title>{title}</title>"
-            f"<style>{TRACEBACK_STYLE}</style>\n"
-            f"<h1>⚠️ {title}</h1><p>{text}\n"
-            f"{_render_traceback_html(request, exception)}",
-            status=status,
-        )
+        return html(f"{text}", status=status)
 
-    # Keeping it minimal with trailing newline for pretty curl/console output
-    return html(
-        f"<!DOCTYPE html><meta charset=UTF-8><title>{title}</title>"
-        "<style>html { font-family: sans-serif }</style>\n"
-        f"<h1>⚠️ {title}</h1><p>{text}\n",
-        status=status,
-        headers=headers,
-    )
+    return html(f"{text}", status=status, headers=headers)
 
 
 def _render_exception(exception):

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -253,18 +253,24 @@ def raw(
     )
 
 
-def html(body, status=200, headers=None):
+def html(body, status=200, headers=None, formatting=None):
     """
     Returns response object with body in html format.
 
     :param body: str or bytes-ish, or an object with __html__ or _repr_html_.
     :param status: Response code.
     :param headers: Custom Headers.
+    :param formatting: Custom formatting (string) containing {body} for insertion point
     """
     if hasattr(body, "__html__"):
         body = body.__html__()
     elif hasattr(body, "_repr_html_"):
         body = body._repr_html_()
+
+    if formatting:
+        if "{body}" in body:
+            body = body.format(**{'body': body})
+
     return HTTPResponse(
         body,
         status=status,


### PR DESCRIPTION
The default error handling should not return html text. Sanic itself can be run as a headless server just for API consumption (ex. CLIs). It would make sense for errors to be propagated with the text they are originally supplied with rather than with surround html tags.  While custom error handling is of course possible, I do believe that this should be the default behavior.

Additionally, custom formatting can be passed as a string as before, just pass `{{body}}`:
`
f"<!DOCTYPE html><meta charset=UTF-8><title>{title}</title><style>{TRACEBACK_STYLE}</style>\n <h1>⚠️ {title}</h1><p>{{body}}\n {_render_traceback_html(request, exception)}"
`

