### PR TITLE
Upgrade httpx

### DIFF
--- a/sanic/response.py
+++ b/sanic/response.py
@@ -249,10 +249,7 @@ def raw(
     :param content_type: the content type (string) of the response.
     """
     return HTTPResponse(
-        body=body,
-        status=status,
-        headers=headers,
-        content_type=content_type,
+        body=body, status=status, headers=headers, content_type=content_type,
     )
 
 

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -249,7 +249,10 @@ def raw(
     :param content_type: the content type (string) of the response.
     """
     return HTTPResponse(
-        body=body, status=status, headers=headers, content_type=content_type,
+        body=body,
+        status=status,
+        headers=headers,
+        content_type=content_type,
     )
 
 

--- a/sanic/testing.py
+++ b/sanic/testing.py
@@ -105,7 +105,9 @@ class SanicTestClient:
 
         if self.port:
             server_kwargs = dict(
-                host=host or self.host, port=self.port, **server_kwargs,
+                host=host or self.host,
+                port=self.port,
+                **server_kwargs,
             )
             host, port = host or self.host, self.port
         else:

--- a/sanic/testing.py
+++ b/sanic/testing.py
@@ -11,6 +11,8 @@ from sanic.response import text
 
 
 ASGI_HOST = "mockserver"
+ASGI_PORT = 1234
+ASGI_BASE_URL = f"http://{ASGI_HOST}:{ASGI_PORT}"
 HOST = "127.0.0.1"
 PORT = None
 
@@ -103,9 +105,7 @@ class SanicTestClient:
 
         if self.port:
             server_kwargs = dict(
-                host=host or self.host,
-                port=self.port,
-                **server_kwargs,
+                host=host or self.host, port=self.port, **server_kwargs,
             )
             host, port = host or self.host, self.port
         else:
@@ -195,24 +195,19 @@ async def app_call_with_return(self, scope, receive, send):
     return await asgi_app()
 
 
-class SanicASGIDispatch(httpx.ASGIDispatch):
-    pass
-
-
 class SanicASGITestClient(httpx.AsyncClient):
     def __init__(
         self,
         app,
-        base_url: str = f"http://{ASGI_HOST}",
+        base_url: str = ASGI_BASE_URL,
         suppress_exceptions: bool = False,
     ) -> None:
         app.__class__.__call__ = app_call_with_return
         app.asgi = True
 
         self.app = app
-
-        dispatch = SanicASGIDispatch(app=app, client=(ASGI_HOST, PORT or 0))
-        super().__init__(dispatch=dispatch, base_url=base_url)
+        transport = httpx.ASGITransport(app=app, client=(ASGI_HOST, ASGI_PORT))
+        super().__init__(transport=transport, base_url=base_url)
 
         self.last_request = None
 

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ requirements = [
     "aiofiles>=0.3.0",
     "websockets>=8.1,<9.0",
     "multidict>=4.0,<5.0",
-    "httpx==0.11.1",
+    "httpx==0.15.4",
 ]
 
 tests_require = [

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,9 +1,9 @@
 import asyncio
 import logging
 import sys
-from unittest.mock import patch
 
 from inspect import isawaitable
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/test_keep_alive_timeout.py
+++ b/tests/test_keep_alive_timeout.py
@@ -3,6 +3,7 @@ import asyncio
 from asyncio import sleep as aio_sleep
 from json import JSONDecodeError
 
+import httpcore
 import httpx
 
 from sanic import Sanic, server
@@ -12,67 +13,26 @@ from sanic.testing import HOST, SanicTestClient
 
 CONFIG_FOR_TESTS = {"KEEP_ALIVE_TIMEOUT": 2, "KEEP_ALIVE": True}
 
-old_conn = None
 PORT = 42101  # test_keep_alive_timeout_reuse doesn't work with random port
 
+from httpcore._async.base import ConnectionState
+from httpcore._async.connection import AsyncHTTPConnection
+from httpcore._types import Origin
 
-class ReusableSanicConnectionPool(
-    httpx.dispatch.connection_pool.ConnectionPool
-):
-    @property
-    def cert(self):
-        return self.ssl.cert
 
-    @property
-    def verify(self):
-        return self.ssl.verify
+class ReusableSanicConnectionPool(httpcore.AsyncConnectionPool):
+    last_reused_connection = None
 
-    @property
-    def trust_env(self):
-        return self.ssl.trust_env
-
-    @property
-    def http2(self):
-        return self.ssl.http2
-
-    async def acquire_connection(self, origin, timeout):
-        global old_conn
-        connection = self.pop_connection(origin)
-
-        if connection is None:
-            pool_timeout = None if timeout is None else timeout.pool_timeout
-
-            await self.max_connections.acquire(timeout=pool_timeout)
-            ssl_config = httpx.config.SSLConfig(
-                cert=self.cert,
-                verify=self.verify,
-                trust_env=self.trust_env,
-                http2=self.http2,
-            )
-            connection = httpx.dispatch.connection.HTTPConnection(
-                origin,
-                ssl=ssl_config,
-                backend=self.backend,
-                release_func=self.release_connection,
-                uds=self.uds,
-            )
-
-        self.active_connections.add(connection)
-
-        if old_conn is not None:
-            if old_conn != connection:
-                raise RuntimeError(
-                    "We got a new connection, wanted the same one!"
-                )
-        old_conn = connection
-
-        return connection
+    async def _get_connection_from_pool(self, *args, **kwargs):
+        conn = await super()._get_connection_from_pool(*args, **kwargs)
+        self.__class__.last_reused_connection = conn
+        return conn
 
 
 class ResusableSanicSession(httpx.AsyncClient):
     def __init__(self, *args, **kwargs) -> None:
-        dispatch = ReusableSanicConnectionPool()
-        super().__init__(dispatch=dispatch, *args, **kwargs)
+        transport = ReusableSanicConnectionPool()
+        super().__init__(transport=transport, *args, **kwargs)
 
 
 class ReuseableSanicTestClient(SanicTestClient):
@@ -258,6 +218,7 @@ def test_keep_alive_timeout_reuse():
         request, response = client.get("/1")
         assert response.status == 200
         assert response.text == "OK"
+        assert ReusableSanicConnectionPool.last_reused_connection
     finally:
         client.kill_server()
 
@@ -270,20 +231,15 @@ def test_keep_alive_client_timeout():
         asyncio.set_event_loop(loop)
         client = ReuseableSanicTestClient(keep_alive_app_client_timeout, loop)
         headers = {"Connection": "keep-alive"}
-        try:
-            request, response = client.get(
-                "/1", headers=headers, request_keepalive=1
-            )
-            assert response.status == 200
-            assert response.text == "OK"
-            loop.run_until_complete(aio_sleep(2))
-            exception = None
-            request, response = client.get("/1", request_keepalive=1)
-        except ValueError as e:
-            exception = e
-        assert exception is not None
-        assert isinstance(exception, ValueError)
-        assert "got a new connection" in exception.args[0]
+        request, response = client.get(
+            "/1", headers=headers, request_keepalive=1
+        )
+        assert response.status == 200
+        assert response.text == "OK"
+        loop.run_until_complete(aio_sleep(2))
+        exception = None
+        request, response = client.get("/1", request_keepalive=1)
+        assert ReusableSanicConnectionPool.last_reused_connection is None
     finally:
         client.kill_server()
 
@@ -298,22 +254,14 @@ def test_keep_alive_server_timeout():
         asyncio.set_event_loop(loop)
         client = ReuseableSanicTestClient(keep_alive_app_server_timeout, loop)
         headers = {"Connection": "keep-alive"}
-        try:
-            request, response = client.get(
-                "/1", headers=headers, request_keepalive=60
-            )
-            assert response.status == 200
-            assert response.text == "OK"
-            loop.run_until_complete(aio_sleep(3))
-            exception = None
-            request, response = client.get("/1", request_keepalive=60)
-        except ValueError as e:
-            exception = e
-        assert exception is not None
-        assert isinstance(exception, ValueError)
-        assert (
-            "Connection reset" in exception.args[0]
-            or "got a new connection" in exception.args[0]
+        request, response = client.get(
+            "/1", headers=headers, request_keepalive=60
         )
+        assert response.status == 200
+        assert response.text == "OK"
+        loop.run_until_complete(aio_sleep(3))
+        exception = None
+        request, response = client.get("/1", request_keepalive=60)
+        assert ReusableSanicConnectionPool.last_reused_connection is None
     finally:
         client.kill_server()

--- a/tests/test_request_stream.py
+++ b/tests/test_request_stream.py
@@ -1,13 +1,14 @@
-import pytest
 import asyncio
+
+import pytest
 
 from sanic.blueprints import Blueprint
 from sanic.exceptions import HeaderExpectationFailed
 from sanic.request import StreamBuffer
 from sanic.response import json, stream, text
+from sanic.server import HttpProtocol
 from sanic.views import CompositionView, HTTPMethodView
 from sanic.views import stream as stream_decorator
-from sanic.server import HttpProtocol
 
 
 data = "abc" * 1_000_000

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
     pytest-sanic
     pytest-sugar
     httpcore==0.3.0
-    httpx==0.11.1
+    httpx==0.15.4
     chardet<=2.3.0
     beautifulsoup4
     gunicorn


### PR DESCRIPTION
I had thought pretty long about whether to get the PR for removing `httpx` requirement (#1850), but that didn't seem quite appropriate just yet.

Because `httpx` is a fairly fast moving project, there were a number of changes needed to be made to some tests as well as the test client. Hopefully, we will get `sanic-testing` completed and then we will not need to deal with these changes here.