### PR TITLE
Add text and json fallback error handlers

### DIFF
--- a/sanic/config.py
+++ b/sanic/config.py
@@ -32,6 +32,7 @@ DEFAULT_CONFIG = {
     "REAL_IP_HEADER": None,
     "PROXIES_COUNT": None,
     "FORWARDED_FOR_HEADER": "X-Forwarded-For",
+    "FALLBACK_ERROR_FORMAT": "html",
 }
 
 

--- a/sanic/errorpages.py
+++ b/sanic/errorpages.py
@@ -4,10 +4,262 @@ from traceback import extract_tb
 
 from sanic.exceptions import SanicException
 from sanic.helpers import STATUS_CODES
-from sanic.response import html
+from sanic.response import html, json, text
 
 
-# Here, There Be Dragons (custom HTML formatting to follow)
+FALLBACK_TEXT = "The server encountered an internal error and cannot complete your request."
+FALLBACK_STATUS = 500
+
+
+class BaseRenderer:
+    def __init__(self, request, exception, debug):
+        self.request = request
+        self.exception = exception
+        self.debug = debug
+
+    @property
+    def headers(self):
+        if isinstance(self.exception, SanicException):
+            return getattr(self.exception, "headers", {})
+        return {}
+
+    @property
+    def status(self):
+        if isinstance(self.exception, SanicException):
+            return getattr(self.exception, "status_code", FALLBACK_STATUS)
+        return FALLBACK_STATUS
+
+    @property
+    def text(self):
+        if self.debug or isinstance(self.exception, SanicException):
+            return str(self.exception)
+        return FALLBACK_TEXT
+
+    @property
+    def title(self):
+        status_text = STATUS_CODES.get(self.status, b"Error Occurred").decode()
+        return f"{self.status} — {status_text}"
+
+    def render(self):
+        output = (
+            self.full
+            if self.debug and not getattr(self.exception, "quiet", False)
+            else self.minimal
+        )
+        return output()
+
+    def minimal(self):
+        raise NotImplementedError
+
+    def full(self):
+        raise NotImplementedError
+
+
+class HTMLRenderer(BaseRenderer):
+    TRACEBACK_STYLE = """
+        html { font-family: sans-serif }
+        h2 { color: #888; }
+        .tb-wrapper p { margin: 0 }
+        .frame-border { margin: 1rem }
+        .frame-line > * { padding: 0.3rem 0.6rem }
+        .frame-line { margin-bottom: 0.3rem }
+        .frame-code { font-size: 16px; padding-left: 4ch }
+        .tb-wrapper { border: 1px solid #eee }
+        .tb-header { background: #eee; padding: 0.3rem; font-weight: bold }
+        .frame-descriptor { background: #e2eafb; font-size: 14px }
+    """
+    TRACEBACK_WRAPPER_HTML = (
+        "<div class=tb-header>{exc_name}: {exc_value}</div>"
+        "<div class=tb-wrapper>{frame_html}</div>"
+    )
+    TRACEBACK_BORDER = (
+        "<div class=frame-border>"
+        "The above exception was the direct cause of the following exception:"
+        "</div>"
+    )
+    TRACEBACK_LINE_HTML = (
+        "<div class=frame-line>"
+        "<p class=frame-descriptor>"
+        "File {0.filename}, line <i>{0.lineno}</i>, "
+        "in <code><b>{0.name}</b></code>"
+        "<p class=frame-code><code>{0.line}</code></p>"
+        "</p></div>"
+    )
+    OUTPUT_HTML = (
+        "<!DOCTYPE html><html><head><meta charset=UTF-8><title>{title}</title>\n"
+        "<style>{style}</style>\n"
+        "</head><body>"
+        "<h1>{title}</h1><div>{text}</div>\n"
+        "{body}"
+        "</body></html>"
+    )
+
+    def full(self):
+        return html(
+            self.OUTPUT_HTML.format(
+                title=self.title,
+                text=self.text,
+                style=self.TRACEBACK_STYLE,
+                body=self._generate_body(),
+            ),
+            status=self.status,
+        )
+
+    def minimal(self):
+        return html(
+            self.OUTPUT_HTML.format(
+                title=self.title,
+                text=self.text,
+                style=self.TRACEBACK_STYLE,
+                body="",
+            ),
+            status=self.status,
+            headers=self.headers,
+        )
+
+    @property
+    def text(self):
+        return escape(super().text)
+
+    @property
+    def title(self):
+        return escape(f"⚠️ {super().title}")
+
+    def _generate_body(self):
+        _, exc_value, __ = sys.exc_info()
+        exceptions = []
+        while exc_value:
+            exceptions.append(self._format_exc(exc_value))
+            exc_value = exc_value.__cause__
+
+        traceback_html = self.TRACEBACK_BORDER.join(reversed(exceptions))
+        appname = escape(self.request.app.name)
+        name = escape(self.exception.__class__.__name__)
+        value = escape(self.exception)
+        path = escape(self.request.path)
+        lines = [
+            f"<h2>Traceback of {appname} (most recent call last):</h2>",
+            f"{traceback_html}",
+            "<div class=summary><p>",
+            f"<b>{name}: {value}</b> while handling path <code>{path}</code>",
+            "</p></div>",
+        ]
+        return "\n".join(lines)
+
+    def _format_exc(self, exc):
+        frames = extract_tb(exc.__traceback__)
+        frame_html = "".join(
+            self.TRACEBACK_LINE_HTML.format(frame) for frame in frames
+        )
+        return self.TRACEBACK_WRAPPER_HTML.format(
+            exc_name=escape(exc.__class__.__name__),
+            exc_value=escape(exc),
+            frame_html=frame_html,
+        )
+
+
+class TextRenderer(BaseRenderer):
+    OUTPUT_TEXT = "{title}\n{bar}\n{text}\n\n{body}"
+    SPACER = "  "
+
+    def full(self):
+        return text(
+            self.OUTPUT_TEXT.format(
+                title=self.title,
+                text=self.text,
+                bar=("=" * len(self.title)),
+                body=self._generate_body(),
+            ),
+            status=self.status,
+        )
+
+    def minimal(self):
+        return text(
+            self.OUTPUT_TEXT.format(
+                title=self.title,
+                text=self.text,
+                bar=("=" * len(self.title)),
+                body="",
+            ),
+            status=self.status,
+            headers=self.headers,
+        )
+
+    @property
+    def title(self):
+        return f"⚠️ {super().title}"
+
+    def _generate_body(self):
+        _, exc_value, __ = sys.exc_info()
+        exceptions = []
+
+        # traceback_html = self.TRACEBACK_BORDER.join(reversed(exceptions))
+        lines = [
+            f"{self.exception.__class__.__name__}: {self.exception} while "
+            f"handling path {self.request.path}",
+            f"Traceback of {self.request.app.name} (most recent call last):\n",
+        ]
+
+        while exc_value:
+            exceptions.append(self._format_exc(exc_value))
+            exc_value = exc_value.__cause__
+
+        return "\n".join(lines + exceptions[::-1])
+
+    def _format_exc(self, exc):
+        frames = "\n\n".join(
+            [
+                f"{self.SPACER * 2}File {frame.filename}, line {frame.lineno}, in "
+                f"{frame.name}\n{self.SPACER * 2}{frame.line}"
+                for frame in extract_tb(exc.__traceback__)
+            ]
+        )
+        return f"{self.SPACER}{exc.__class__.__name__}: {exc}\n{frames}"
+
+
+class JSONRenderer(BaseRenderer):
+    def full(self):
+        output = self._generate_output(full=True)
+        return json(output, status=self.status)
+
+    def minimal(self):
+        output = self._generate_output(full=False)
+        return json(output, status=self.status)
+
+    def _generate_output(self, *, full):
+        output = {
+            "description": self.title,
+            "status": self.status,
+            "message": self.text,
+        }
+
+        if full:
+            _, exc_value, __ = sys.exc_info()
+            exceptions = []
+
+            while exc_value:
+                exceptions.append(
+                    {
+                        "type": exc_value.__class__.__name__,
+                        "exception": str(exc_value),
+                        "frames": [
+                            {
+                                "file": frame.filename,
+                                "line": frame.lineno,
+                                "name": frame.name,
+                                "src": frame.line,
+                            }
+                            for frame in extract_tb(exc_value.__traceback__)
+                        ],
+                    }
+                )
+                exc_value = exc_value.__cause__
+
+            output["path"] = self.request.path
+            output["args"] = self.request.args
+            output["exceptions"] = exceptions[::-1]
+
+        return output
 
 
 def escape(text):
@@ -15,103 +267,13 @@ def escape(text):
     return f"{text}".replace("&", "&amp;").replace("<", "&lt;")
 
 
-def exception_response(request, exception, debug):
-    status = 500
-    text = (
-        "The server encountered an internal error "
-        "and cannot complete your request."
-    )
+def exception_response(request, exception, debug, renderer=None):
+    if not renderer:
+        if request.app.config.FALLBACK_ERROR_FORMAT == "text":
+            renderer = TextRenderer
+        elif request.app.config.FALLBACK_ERROR_FORMAT == "json":
+            renderer = JSONRenderer
+        else:
+            renderer = HTMLRenderer
 
-    headers = {}
-    if isinstance(exception, SanicException):
-        text = f"{exception}"
-        status = getattr(exception, "status_code", status)
-        headers = getattr(exception, "headers", headers)
-    elif debug:
-        text = f"{exception}"
-
-    status_text = STATUS_CODES.get(status, b"Error Occurred").decode()
-    title = escape(f"{status} — {status_text}")
-    text = escape(text)
-
-    if debug and not getattr(exception, "quiet", False):
-        return html(
-            f"<!DOCTYPE html><meta charset=UTF-8><title>{title}</title>"
-            f"<style>{TRACEBACK_STYLE}</style>\n"
-            f"<h1>⚠️ {title}</h1><p>{text}\n"
-            f"{_render_traceback_html(request, exception)}",
-            status=status,
-        )
-
-    # Keeping it minimal with trailing newline for pretty curl/console output
-    return html(
-        f"<!DOCTYPE html><meta charset=UTF-8><title>{title}</title>"
-        "<style>html { font-family: sans-serif }</style>\n"
-        f"<h1>⚠️ {title}</h1><p>{text}\n",
-        status=status,
-        headers=headers,
-    )
-
-
-def _render_exception(exception):
-    frames = extract_tb(exception.__traceback__)
-    frame_html = "".join(TRACEBACK_LINE_HTML.format(frame) for frame in frames)
-    return TRACEBACK_WRAPPER_HTML.format(
-        exc_name=escape(exception.__class__.__name__),
-        exc_value=escape(exception),
-        frame_html=frame_html,
-    )
-
-
-def _render_traceback_html(request, exception):
-    exc_type, exc_value, tb = sys.exc_info()
-    exceptions = []
-    while exc_value:
-        exceptions.append(_render_exception(exc_value))
-        exc_value = exc_value.__cause__
-
-    traceback_html = TRACEBACK_BORDER.join(reversed(exceptions))
-    appname = escape(request.app.name)
-    name = escape(exception.__class__.__name__)
-    value = escape(exception)
-    path = escape(request.path)
-    return (
-        f"<h2>Traceback of {appname} (most recent call last):</h2>"
-        f"{traceback_html}"
-        "<div class=summary><p>"
-        f"<b>{name}: {value}</b> while handling path <code>{path}</code>"
-    )
-
-
-TRACEBACK_STYLE = """
-    html { font-family: sans-serif }
-    h2 { color: #888; }
-    .tb-wrapper p { margin: 0 }
-    .frame-border { margin: 1rem }
-    .frame-line > * { padding: 0.3rem 0.6rem }
-    .frame-line { margin-bottom: 0.3rem }
-    .frame-code { font-size: 16px; padding-left: 4ch }
-    .tb-wrapper { border: 1px solid #eee }
-    .tb-header { background: #eee; padding: 0.3rem; font-weight: bold }
-    .frame-descriptor { background: #e2eafb; font-size: 14px }
-"""
-
-TRACEBACK_WRAPPER_HTML = (
-    "<div class=tb-header>{exc_name}: {exc_value}</div>"
-    "<div class=tb-wrapper>{frame_html}</div>"
-)
-
-TRACEBACK_BORDER = (
-    "<div class=frame-border>"
-    "The above exception was the direct cause of the following exception:"
-    "</div>"
-)
-
-TRACEBACK_LINE_HTML = (
-    "<div class=frame-line>"
-    "<p class=frame-descriptor>"
-    "File {0.filename}, line <i>{0.lineno}</i>, "
-    "in <code><b>{0.name}</b></code>"
-    "<p class=frame-code><code>{0.line}</code>"
-    "</div>"
-)
+    return renderer(request, exception, debug).render()

--- a/sanic/errorpages.py
+++ b/sanic/errorpages.py
@@ -261,6 +261,10 @@ class JSONRenderer(BaseRenderer):
 
         return output
 
+    @property
+    def title(self):
+        return STATUS_CODES.get(self.status, b"Error Occurred").decode()
+
 
 def escape(text):
     """Minimal HTML escaping, not for attribute values (unlike html.escape)."""

--- a/sanic/errorpages.py
+++ b/sanic/errorpages.py
@@ -12,6 +12,8 @@ from sanic.response import HTTPResponse, html, json, text
 
 try:
     from ujson import dumps
+
+    dumps = partial(dumps, escape_forward_slashes=False)
 except ImportError:  # noqa
     from json import dumps
 
@@ -230,15 +232,13 @@ class TextRenderer(BaseRenderer):
 
 
 class JSONRenderer(BaseRenderer):
-    dumps = partial(dumps, escape_forward_slashes=False)
-
     def full(self):
         output = self._generate_output(full=True)
-        return json(output, status=self.status, dumps=self.dumps)
+        return json(output, status=self.status, dumps=dumps)
 
     def minimal(self):
         output = self._generate_output(full=False)
-        return json(output, status=self.status, dumps=self.dumps)
+        return json(output, status=self.status, dumps=dumps)
 
     def _generate_output(self, *, full):
         output = {

--- a/sanic/errorpages.py
+++ b/sanic/errorpages.py
@@ -15,7 +15,7 @@ try:
 
     dumps = partial(dumps, escape_forward_slashes=False)
 except ImportError:  # noqa
-    from json import dumps
+    from json import dumps  # type: ignore
 
 
 FALLBACK_TEXT = (
@@ -302,7 +302,7 @@ def exception_response(
     request: Request,
     exception: Exception,
     debug: bool,
-    renderer: t.Optional[BaseRenderer] = None,
+    renderer: t.Type[t.Optional[BaseRenderer]] = None,
 ) -> HTTPResponse:
     """Render a response for the default FALLBACK exception handler"""
 
@@ -326,4 +326,5 @@ def exception_response(
                 render_format = request.app.config.FALLBACK_ERROR_FORMAT
                 renderer = RENDERERS_BY_CONFIG.get(render_format, renderer)
 
+    renderer = t.cast(t.Type[BaseRenderer], renderer)
     return renderer(request, exception, debug).render()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -126,7 +126,9 @@ def test_app_handle_request_handler_is_none(app, monkeypatch):
     def handler(request):
         return text("test")
 
-    request, response = app.test_client.get("/test")
+    _, response = app.test_client.get("/test")
+
+    print(">>>>>>>>>>>", response.body)
 
     assert (
         "'None' was returned while requesting a handler from the router"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -128,8 +128,6 @@ def test_app_handle_request_handler_is_none(app, monkeypatch):
 
     _, response = app.test_client.get("/test")
 
-    print(">>>>>>>>>>>", response.body)
-
     assert (
         "'None' was returned while requesting a handler from the router"
         in response.text

--- a/tests/test_errorpages.py
+++ b/tests/test_errorpages.py
@@ -1,0 +1,86 @@
+import pytest
+
+from sanic import Sanic
+from sanic.errorpages import exception_response
+from sanic.exceptions import NotFound
+from sanic.request import Request
+from sanic.response import HTTPResponse
+
+
+@pytest.fixture
+def app():
+    app = Sanic("error_page_testing")
+
+    @app.route("/error", methods=["GET", "POST"])
+    def err(request):
+        raise Exception("something went wrong")
+
+    return app
+
+
+@pytest.fixture
+def fake_request(app):
+    return Request(b"/foobar", {}, "1.1", "GET", None, app)
+
+
+@pytest.mark.parametrize(
+    "fallback,content_type, exception, status",
+    (
+        (None, "text/html; charset=utf-8", Exception, 500),
+        ("html", "text/html; charset=utf-8", Exception, 500),
+        ("auto", "text/html; charset=utf-8", Exception, 500),
+        ("text", "text/plain; charset=utf-8", Exception, 500),
+        ("json", "application/json", Exception, 500),
+        (None, "text/html; charset=utf-8", NotFound, 404),
+        ("html", "text/html; charset=utf-8", NotFound, 404),
+        ("auto", "text/html; charset=utf-8", NotFound, 404),
+        ("text", "text/plain; charset=utf-8", NotFound, 404),
+        ("json", "application/json", NotFound, 404),
+    ),
+)
+def test_should_return_html_valid_setting(
+    fake_request, fallback, content_type, exception, status
+):
+    if fallback:
+        fake_request.app.config.FALLBACK_ERROR_FORMAT = fallback
+
+    try:
+        raise exception("bad stuff")
+    except Exception as e:
+        response = exception_response(fake_request, e, True)
+
+    assert isinstance(response, HTTPResponse)
+    assert response.status == status
+    assert response.content_type == content_type
+
+
+def test_auto_fallback_with_data(app):
+    app.config.FALLBACK_ERROR_FORMAT = "auto"
+
+    _, response = app.test_client.get("/error")
+    assert response.status == 500
+    assert response.content_type == "text/html; charset=utf-8"
+
+    _, response = app.test_client.post("/error", json={"foo": "bar"})
+    assert response.status == 500
+    assert response.content_type == "application/json"
+
+    _, response = app.test_client.post("/error", data={"foo": "bar"})
+    assert response.status == 500
+    assert response.content_type == "text/html; charset=utf-8"
+
+
+def test_auto_fallback_with_content_type(app):
+    app.config.FALLBACK_ERROR_FORMAT = "auto"
+
+    _, response = app.test_client.get(
+        "/error", headers={"content-type": "application/json"}
+    )
+    assert response.status == 500
+    assert response.content_type == "application/json"
+
+    _, response = app.test_client.get(
+        "/error", headers={"content-type": "text/plain"}
+    )
+    assert response.status == 500
+    assert response.content_type == "text/plain; charset=utf-8"


### PR DESCRIPTION
Replaces #1905 

PR #1768 added HTML default exception pages. This PR adds two alternative fallback exception pages: text and JSON.

*This is **NOT** meant to replace custom error handlers, but is meant to be for **fallback***.

This is configurable with:

```python
app.config.FALLBACK_ERROR_FORMAT = "text"
# or
app.config.FALLBACK_ERROR_FORMAT = "json"
```

The **default** will still be **HTML**. And, the HTML page is untouched (except for some fixes to make valid HTML.

Just like in HTML, there are two handlers: one for debuggable exception responses, the other for minimal responses.

### Text

```
⚠️ 500 — Internal Server Error
==============================
foobar

Exception: foobar while handling path /hello
Traceback of __BASE__ (most recent call last):

  Exception: foobar
    File /path/to/sanic/app.py, line 938, in handle_request
    response = await response

    File server.py, line 12, in foo
    raise Exception("foobar")
```

```
⚠️ 500 — Internal Server Error
==============================
The server encountered an internal error and cannot complete your request.

```

### JSON

```json
{
  "description": "Internal Server Error",
  "status": 500,
  "message": "foobar",
  "path": "/hello",
  "args": {
    "name": [
      "world"
    ]
  },
  "exceptions": [
    {
      "type": "Exception",
      "exception": "foobar",
      "frames": [
        {
          "file": "/path/to/sanic/app.py",
          "line": 938,
          "name": "handle_request",
          "src": "response = await response"
        },
        {
          "file": "server.py",
          "line": 12,
          "name": "foo",
          "src": "raise Exception(\"foobar\")"
        }
      ]
    }
  ]
}
```

```json
{
  "description": "Internal Server Error",
  "status": 500,
  "message": "The server encountered an internal error and cannot complete your request."
}

```
