### PR TITLE
Fix static routes registration on a blueprint

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -676,9 +676,10 @@ class Sanic:
         :param strict_slashes: Instruct :class:`Sanic` to check if the request
             URLs need to terminate with a */*
         :param content_type: user defined content type for header
-        :return: None
+        :return: routes registered on the router
+        :rtype: List[sanic.router.Route]
         """
-        static_register(
+        return static_register(
             self,
             uri,
             file_or_directory,

--- a/sanic/blueprints.py
+++ b/sanic/blueprints.py
@@ -143,7 +143,18 @@ class Blueprint:
             if _routes:
                 routes += _routes
 
+        # Static Files
+        for future in self.statics:
+            # Prepend the blueprint URI prefix if available
+            uri = url_prefix + future.uri if url_prefix else future.uri
+            _routes = app.static(
+                uri, future.file_or_directory, *future.args, **future.kwargs
+            )
+            if _routes:
+                routes += _routes
+
         route_names = [route.name for route in routes if route]
+
         # Middleware
         for future in self.middlewares:
             if future.args or future.kwargs:
@@ -159,14 +170,6 @@ class Blueprint:
         # Exceptions
         for future in self.exceptions:
             app.exception(*future.args, **future.kwargs)(future.handler)
-
-        # Static Files
-        for future in self.statics:
-            # Prepend the blueprint URI prefix if available
-            uri = url_prefix + future.uri if url_prefix else future.uri
-            app.static(
-                uri, future.file_or_directory, *future.args, **future.kwargs
-            )
 
         # Event listeners
         for event, listeners in self.listeners.items():

--- a/sanic/static.py
+++ b/sanic/static.py
@@ -134,6 +134,8 @@ def register(
                               threshold size to switch to file_stream()
     :param name: user defined name used for url_for
     :param content_type: user defined content type for header
+    :return: registered static routes
+    :rtype: List[sanic.router.Route]
     """
     # If we're not trying to match a file directly,
     # serve from the folder
@@ -155,10 +157,11 @@ def register(
         )
     )
 
-    app.route(
+    _routes, _ = app.route(
         uri,
         methods=["GET", "HEAD"],
         name=name,
         host=host,
         strict_slashes=strict_slashes,
     )(_handler)
+    return _routes


### PR DESCRIPTION
Adds ability for app.static() to return the routes it created.
This allows blueprint registration to add the bp's static routes to its list of own routes.
So now blueprint middlewares will apply to a blueprint's static file routes.
Fixes #1953