### PR TITLE
Fix load module test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,13 +80,13 @@ requirements = [
     ujson,
     "aiofiles>=0.3.0",
     "websockets>=8.1,<9.0",
-    "multidict>=4.0,<5.0",
+    "multidict==5.0.0",
     "httpx==0.15.4",
 ]
 
 tests_require = [
     "pytest==5.2.1",
-    "multidict>=4.0,<5.0",
+    "multidict==5.0.0",
     "gunicorn",
     "pytest-cov",
     "httpcore==0.3.0",

--- a/tests/test_load_module_from_file_location.py
+++ b/tests/test_load_module_from_file_location.py
@@ -21,7 +21,10 @@ def test_load_module_from_file_location(loaded_module_from_file_location):
 
 @pytest.mark.dependency(depends=["test_load_module_from_file_location"])
 def test_loaded_module_from_file_location_name(loaded_module_from_file_location,):
-    assert loaded_module_from_file_location.__name__ == "app_test_config"
+    name = loaded_module_from_file_location.__name__
+    if "C:\\" in name:
+        name = name.split("\\")[-1]
+    assert name == "app_test_config"
 
 
 def test_load_module_from_file_location_with_non_existing_env_variable():

--- a/tests/test_load_module_from_file_location.py
+++ b/tests/test_load_module_from_file_location.py
@@ -10,7 +10,7 @@ from sanic.utils import load_module_from_file_location
 @pytest.fixture
 def loaded_module_from_file_location():
     return load_module_from_file_location(
-        str(Path(__file__).parent / "static/app_test_config.py")
+        str(Path(__file__).parent / "static" / "app_test_config.py")
     )
 
 
@@ -20,9 +20,7 @@ def test_load_module_from_file_location(loaded_module_from_file_location):
 
 
 @pytest.mark.dependency(depends=["test_load_module_from_file_location"])
-def test_loaded_module_from_file_location_name(
-    loaded_module_from_file_location,
-):
+def test_loaded_module_from_file_location_name(loaded_module_from_file_location,):
     assert loaded_module_from_file_location.__name__ == "app_test_config"
 
 


### PR DESCRIPTION
There was a broken test in appveyor because of how the module's `__name__` was being reported.