### PR TITLE
Sanic CLI upgrade

### DIFF
--- a/sanic/__main__.py
+++ b/sanic/__main__.py
@@ -9,15 +9,25 @@ from sanic.app import Sanic
 from sanic.log import logger
 
 
+class SanicArgumentParser(ArgumentParser):
+    def add_bool_arguments(self, *args, **kwargs):
+        group = self.add_mutually_exclusive_group()
+        group.add_argument(*args, action="store_true", **kwargs)
+        kwargs["help"] = "no " + kwargs["help"]
+        group.add_argument(
+            "--no-" + args[0][2:], *args[1:], action="store_false", **kwargs
+        )
+
+
 def main():
-    parser = ArgumentParser(prog="sanic")
+    parser = SanicArgumentParser(prog="sanic")
     parser.add_argument(
         "-H",
         "--host",
         dest="host",
         type=str,
         default="127.0.0.1",
-        help="Host address [default 127.0.0.1]",
+        help="host address [default 127.0.0.1]",
     )
     parser.add_argument(
         "-p",
@@ -25,7 +35,7 @@ def main():
         dest="port",
         type=int,
         default=8000,
-        help="Port to serve on [default 8000]",
+        help="port to serve on [default 8000]",
     )
     parser.add_argument(
         "-u",
@@ -33,13 +43,13 @@ def main():
         dest="unix",
         type=str,
         default="",
-        help="Location of unix socket",
+        help="location of unix socket",
     )
     parser.add_argument(
-        "--cert", dest="cert", type=str, help="Location of certificate for SSL"
+        "--cert", dest="cert", type=str, help="location of certificate for SSL"
     )
     parser.add_argument(
-        "--key", dest="key", type=str, help="Location of keyfile for SSL."
+        "--key", dest="key", type=str, help="location of keyfile for SSL."
     )
     parser.add_argument(
         "-w",
@@ -47,14 +57,17 @@ def main():
         dest="workers",
         type=int,
         default=1,
-        help="Number of worker processes [default 1]",
+        help="number of worker processes [default 1]",
     )
     parser.add_argument("--debug", dest="debug", action="store_true")
+    parser.add_bool_arguments(
+        "--access-logs", dest="access_log", help="display access logs"
+    )
     parser.add_argument(
         "-v", "--version", action="version", version=f"Sanic {__version__}",
     )
     parser.add_argument(
-        "module", help="Path to your Sanic app. Example: path.to.server:app"
+        "module", help="path to your Sanic app. Example: path.to.server:app"
     )
     args = parser.parse_args()
 
@@ -93,6 +106,7 @@ def main():
             unix=args.unix,
             workers=args.workers,
             debug=args.debug,
+            access_log=args.access_log,
             ssl=ssl,
         )
     except ImportError as e:

--- a/sanic/__main__.py
+++ b/sanic/__main__.py
@@ -1,10 +1,10 @@
 import os
 import sys
-
 from argparse import ArgumentParser
 from importlib import import_module
 from typing import Any, Dict, Optional
 
+from sanic import __version__
 from sanic.app import Sanic
 from sanic.log import logger
 
@@ -22,6 +22,9 @@ def main():
     )
     parser.add_argument("--workers", dest="workers", type=int, default=1)
     parser.add_argument("--debug", dest="debug", action="store_true")
+    parser.add_argument(
+        "--version", action="version", version=f"Sanic {__version__}",
+    )
     parser.add_argument("module")
     args = parser.parse_args()
 
@@ -30,9 +33,12 @@ def main():
         if module_path not in sys.path:
             sys.path.append(module_path)
 
-        module_parts = args.module.split(".")
-        module_name = ".".join(module_parts[:-1])
-        app_name = module_parts[-1]
+        if ":" in args.module:
+            module_name, app_name = args.module.rsplit(":", 1)
+        else:
+            module_parts = args.module.split(".")
+            module_name = ".".join(module_parts[:-1])
+            app_name = module_parts[-1]
 
         module = import_module(module_name)
         app = getattr(module, app_name, None)

--- a/sanic/__main__.py
+++ b/sanic/__main__.py
@@ -11,21 +11,51 @@ from sanic.log import logger
 
 def main():
     parser = ArgumentParser(prog="sanic")
-    parser.add_argument("--host", dest="host", type=str, default="127.0.0.1")
-    parser.add_argument("--port", dest="port", type=int, default=8000)
-    parser.add_argument("--unix", dest="unix", type=str, default="")
     parser.add_argument(
-        "--cert", dest="cert", type=str, help="location of certificate for SSL"
+        "-H",
+        "--host",
+        dest="host",
+        type=str,
+        default="127.0.0.1",
+        help="Host address [default 127.0.0.1]",
     )
     parser.add_argument(
-        "--key", dest="key", type=str, help="location of keyfile for SSL."
+        "-p",
+        "--port",
+        dest="port",
+        type=int,
+        default=8000,
+        help="Port to serve on [default 8000]",
     )
-    parser.add_argument("--workers", dest="workers", type=int, default=1)
+    parser.add_argument(
+        "-u",
+        "--unix",
+        dest="unix",
+        type=str,
+        default="",
+        help="Location of unix socket",
+    )
+    parser.add_argument(
+        "--cert", dest="cert", type=str, help="Location of certificate for SSL"
+    )
+    parser.add_argument(
+        "--key", dest="key", type=str, help="Location of keyfile for SSL."
+    )
+    parser.add_argument(
+        "-w",
+        "--workers",
+        dest="workers",
+        type=int,
+        default=1,
+        help="Number of worker processes [default 1]",
+    )
     parser.add_argument("--debug", dest="debug", action="store_true")
     parser.add_argument(
-        "--version", action="version", version=f"Sanic {__version__}",
+        "-v", "--version", action="version", version=f"Sanic {__version__}",
     )
-    parser.add_argument("module")
+    parser.add_argument(
+        "module", help="Path to your Sanic app. Example: path.to.server:app"
+    )
     args = parser.parse_args()
 
     try:

--- a/sanic/__main__.py
+++ b/sanic/__main__.py
@@ -1,11 +1,12 @@
 import os
 import sys
-from argparse import ArgumentParser
+from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from importlib import import_module
 from typing import Any, Dict, Optional
 
 from sanic import __version__
 from sanic.app import Sanic
+from sanic.config import BASE_LOGO
 from sanic.log import logger
 
 
@@ -20,7 +21,9 @@ class SanicArgumentParser(ArgumentParser):
 
 
 def main():
-    parser = SanicArgumentParser(prog="sanic")
+    parser = SanicArgumentParser(
+        prog="sanic", description=BASE_LOGO, formatter_class=RawDescriptionHelpFormatter
+    )
     parser.add_argument(
         "-H",
         "--host",

--- a/sanic/__main__.py
+++ b/sanic/__main__.py
@@ -1,5 +1,6 @@
 import os
 import sys
+
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from importlib import import_module
 from typing import Any, Dict, Optional
@@ -22,7 +23,9 @@ class SanicArgumentParser(ArgumentParser):
 
 def main():
     parser = SanicArgumentParser(
-        prog="sanic", description=BASE_LOGO, formatter_class=RawDescriptionHelpFormatter
+        prog="sanic",
+        description=BASE_LOGO,
+        formatter_class=RawDescriptionHelpFormatter,
     )
     parser.add_argument(
         "-H",
@@ -67,7 +70,10 @@ def main():
         "--access-logs", dest="access_log", help="display access logs"
     )
     parser.add_argument(
-        "-v", "--version", action="version", version=f"Sanic {__version__}",
+        "-v",
+        "--version",
+        action="version",
+        version=f"Sanic {__version__}",
     )
     parser.add_argument(
         "module", help="path to your Sanic app. Example: path.to.server:app"

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -735,6 +735,7 @@ def test_static_blueprint_name(app: Sanic, static_file_directory, file_name):
     _, response = app.test_client.get("/static/test.file/")
     assert response.status == 200
 
+
 @pytest.mark.parametrize("file_name", ["test.file"])
 def test_static_blueprintp_mw(app: Sanic, static_file_directory, file_name):
     current_file = inspect.getfile(inspect.currentframe())
@@ -745,7 +746,7 @@ def test_static_blueprintp_mw(app: Sanic, static_file_directory, file_name):
 
     bp = Blueprint(name="test_mw", url_prefix="")
 
-    @bp.middleware('request')
+    @bp.middleware("request")
     def bp_mw1(request):
         nonlocal triggered
         triggered = True
@@ -754,7 +755,7 @@ def test_static_blueprintp_mw(app: Sanic, static_file_directory, file_name):
         "/test.file",
         get_file_path(static_file_directory, file_name),
         strict_slashes=True,
-        name="static"
+        name="static",
     )
 
     app.blueprint(bp)

--- a/tests/test_load_module_from_file_location.py
+++ b/tests/test_load_module_from_file_location.py
@@ -20,7 +20,9 @@ def test_load_module_from_file_location(loaded_module_from_file_location):
 
 
 @pytest.mark.dependency(depends=["test_load_module_from_file_location"])
-def test_loaded_module_from_file_location_name(loaded_module_from_file_location,):
+def test_loaded_module_from_file_location_name(
+    loaded_module_from_file_location,
+):
     name = loaded_module_from_file_location.__name__
     if "C:\\" in name:
         name = name.split("\\")[-1]


### PR DESCRIPTION
Fairly simple changes here:

1. Add support for `path.to.server:app` as well as existing `path.to.server.app`
1. Add a `-v/--version` to display Sanic version info
1. Add some more `help_text`
1. Add `--access-logs/--no-access-logs`

```
$ sanic -h
usage: sanic [-h] [-H HOST] [-p PORT] [-u UNIX] [--cert CERT] [--key KEY]
             [-w WORKERS] [--debug] [--access-logs | --no-access-logs] [-v]
             module

                 Sanic
         Build Fast. Run Fast.

positional arguments:
  module                path to your Sanic app. Example: path.to.server:app

optional arguments:
  -h, --help            show this help message and exit
  -H HOST, --host HOST  host address [default 127.0.0.1]
  -p PORT, --port PORT  port to serve on [default 8000]
  -u UNIX, --unix UNIX  location of unix socket
  --cert CERT           location of certificate for SSL
  --key KEY             location of keyfile for SSL.
  -w WORKERS, --workers WORKERS
                        number of worker processes [default 1]
  --debug
  --access-logs         display access logs
  --no-access-logs      no display access logs
  -v, --version         show program's version number and exit

```