### PR TITLE
remove upper bound for multidict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,13 +80,13 @@ requirements = [
     ujson,
     "aiofiles>=0.6.0",
     "websockets>=8.1,<9.0",
-    "multidict==5.0.0",
+    "multidict>=5.0,<6.0",
     "httpx==0.15.4",
 ]
 
 tests_require = [
     "pytest==5.2.1",
-    "multidict==5.0.0",
+    "multidict>=5.0,<6.0",
     "gunicorn",
     "pytest-cov",
     "httpcore==0.3.0",


### PR DESCRIPTION
Is there a reason this had a hard pin? It would be beneficial to set this range as wide as possible to avoid conflicts with Sanic users.