### PR TITLE
Add py.typed file

### DIFF
--- a/changelogs/1970.misc.rst
+++ b/changelogs/1970.misc.rst
@@ -1,0 +1,1 @@
+Adds py.typed file to expose type information to other packages.

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup_kwargs = {
     ),
     "long_description": long_description,
     "packages": ["sanic"],
+    "package_data": {"sanic": ["py.typed"]},
     "platforms": "any",
     "python_requires": ">=3.6",
     "classifiers": [


### PR DESCRIPTION
I was happy to see that Sanic has some type annotations in the codebase! But `mypy` couldn't find those annotations when I ran it on my project. This is because Sanic hasn't added a `py.typed` file; see [PEP-561](https://www.python.org/dev/peps/pep-0561/#packaging-type-information) for details. This PR adds the file and exposes it through `package_data`.