### PR TITLE
App registry

### DIFF
--- a/docs/sanic/getting_started.rst
+++ b/docs/sanic/getting_started.rst
@@ -60,3 +60,21 @@ Open the address `http://0.0.0.0:8000 <http://0.0.0.0:8000>`_ in your web browse
 the message *Hello world!*.
 
 You now have a working Sanic server!
+
+5. Application registry
+-----------------------
+
+When you instantiate a Sanic instance, that can be retrieved at a later time from the Sanic app registry. This can be useful, for example, if you need to access your Sanic instance from a location where it is not otherwise accessible.
+
+.. code-block:: python
+
+    # ./path/to/server.py
+    from sanic import Sanic
+
+    app = Sanic("my_awesome_server")
+
+    # ./path/to/somewhere_else.py
+    from sanic import Sanic
+
+    app = Sanic.get_app("my_awesome_server")
+

--- a/docs/sanic/getting_started.rst
+++ b/docs/sanic/getting_started.rst
@@ -78,3 +78,8 @@ When you instantiate a Sanic instance, that can be retrieved at a later time fro
 
     app = Sanic.get_app("my_awesome_server")
 
+If you call ``Sanic.get_app("non-existing")`` on an app that does not exist, it will raise ``SanicException`` by default. You can, instead, force the method to return a new instance of ``Sanic`` with that name:
+
+.. code-block:: python
+
+    app = Sanic.get_app("my_awesome_server", force_create=True)

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -2,7 +2,6 @@ import logging
 import logging.config
 import os
 import re
-import warnings
 
 from asyncio import CancelledError, Protocol, ensure_future, get_event_loop
 from collections import defaultdict, deque

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -1424,9 +1424,11 @@ class Sanic:
         cls._app_registry[name] = app
 
     @classmethod
-    def get_app(cls, name: str) -> "Sanic":
+    def get_app(cls, name: str, *, force_create: bool = False) -> "Sanic":
         """Retrieve an instantiated Sanic instance"""
         try:
             return cls._app_registry[name]
         except KeyError:
+            if force_create:
+                return cls(name)
             raise SanicException(f'Sanic app name "{name}" not found.')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ from sanic.router import RouteExists, Router
 
 
 random.seed("Pack my box with five dozen liquor jugs.")
+Sanic.test_mode = True
 
 if sys.platform in ["win32", "cygwin"]:
     collect_ignore = ["test_worker.py"]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -295,3 +295,14 @@ def test_app_registry_name_reuse():
 def test_app_registry_retrieval():
     instance = Sanic("test")
     assert Sanic.get_app("test") is instance
+
+
+def test_get_app_does_not_exist():
+    with pytest.raises(SanicException):
+        Sanic.get_app("does-not-exist")
+
+
+def test_get_app_does_not_exist_force_create():
+    assert isinstance(
+        Sanic.get_app("does-not-exist", force_create=True), Sanic
+    )

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -258,7 +258,7 @@ def test_handle_request_with_nested_sanic_exception(app, monkeypatch, caplog):
 
 
 def test_app_name_required():
-    with pytest.deprecated_call():
+    with pytest.raises(SanicException):
         Sanic()
 
 
@@ -274,14 +274,24 @@ def test_app_has_test_mode_sync():
     assert response.status == 200
 
 
-# @pytest.mark.asyncio
-# async def test_app_has_test_mode_async():
-#     app = Sanic("test")
+def test_app_registry():
+    instance = Sanic("test")
+    assert Sanic._app_registry["test"] is instance
 
-#     @app.get("/")
-#     async def handler(request):
-#         assert request.app.test_mode
-#         return text("test")
 
-#     _, response = await app.asgi_client.get("/")
-#     assert response.status == 200
+def test_app_registry_wrong_type():
+    with pytest.raises(SanicException):
+        Sanic.register_app(1)
+
+
+def test_app_registry_name_reuse():
+    Sanic("test")
+    Sanic.test_mode = False
+    with pytest.raises(SanicException):
+        Sanic("test")
+    Sanic.test_mode = True
+
+
+def test_app_registry_retrieval():
+    instance = Sanic("test")
+    assert Sanic.get_app("test") is instance


### PR DESCRIPTION
See #1968 

The purpose of this is to add a convenience for access an application instance.

```python
from sanic import Sanic

app = Sanic.get_app("my_awesome_server")
```